### PR TITLE
chore: migrate ESLint to Biome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,8 @@ instructions.md
 
 # Historical data
 /data
+*.csv
+*_report*.txt
+*_trades*.txt
 
 .cursor/mcp.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,12 +6,7 @@
   "typescript.updateImportsOnFileMove.enabled": "always",
 
   // ESLint
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@ Live Engine is a universal real-time market data engine and paper/live trading b
 pnpm dev              # Run dev server with Turbopack
 pnpm build            # Production build
 pnpm start            # Run production server
-pnpm lint             # ESLint check
+pnpm lint             # Biome check (linting + formatting)
+pnpm lint:fix         # Biome auto-fix
+pnpm format           # Biome format
 
 # CLI (stub implementation)
 pnpm cli              # Show CLI help

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "files": {
+    "ignore": ["node_modules", ".next", "out", "build", "dist"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  }
+}

--- a/docs/binance-data-retrieval.md
+++ b/docs/binance-data-retrieval.md
@@ -1,0 +1,2118 @@
+# Binance Data Retrieval Guide
+
+Complete guide to retrieve market data from Binance for use in trading applications.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Dependencies](#dependencies)
+3. [Real-time Data via WebSocket](#1-real-time-data-via-websocket)
+4. [Historical Data via REST API](#2-historical-data-via-rest-api)
+5. [Bulk Download from Binance Data Portal](#3-bulk-download-from-binance-data-portal)
+6. [Redis Caching](#4-redis-caching)
+7. [Server-Sent Events (SSE) for Browser](#5-server-sent-events-sse-for-browser)
+8. [CLI Commands](#6-cli-commands)
+9. [CSV Conversion Tools](#7-csv-conversion-tools)
+10. [CSV Merging Tools](#8-csv-merging-tools)
+11. [Data Adaptation & Transformation](#9-data-adaptation--transformation)
+12. [Database Schema](#10-database-schema)
+
+---
+
+## Overview
+
+Three methods to retrieve Binance data:
+
+| Method | Speed | Use Case | Auth Required |
+|--------|-------|----------|---------------|
+| WebSocket | Real-time | Live tickers, streaming | No |
+| REST API | Medium | Small datasets (<1000 candles) | No |
+| Data Portal | Fast | Large historical datasets | No |
+
+---
+
+## Dependencies
+
+```bash
+# Core dependencies
+pnpm add ws                    # WebSocket client (Node.js)
+pnpm add @upstash/redis        # Redis caching (optional)
+pnpm add @supabase/supabase-js # Database storage (optional)
+pnpm add commander             # CLI framework (optional)
+pnpm add dotenv                # Environment variables
+
+# TypeScript
+pnpm add -D typescript tsx @types/node @types/ws
+```
+
+**package.json scripts:**
+
+```json
+{
+  "scripts": {
+    "cli": "tsx src/cli/index.ts"
+  }
+}
+```
+
+---
+
+## 1. Real-time Data via WebSocket
+
+### binance-websocket.ts
+
+```typescript
+import WebSocket from 'ws';
+
+export type Asset = 'btcusdt' | 'ethusdt' | 'bnbusdt' | 'solusdt' | 'adausdt';
+
+export type TickData = {
+  asset: string;
+  price: number;
+  volume: number;
+  timestamp: number;
+  high24h: number;
+  low24h: number;
+  change24h: number;
+};
+
+type TickHandler = (tick: TickData) => void | Promise<void>;
+
+class BinanceWebSocketClient {
+  private ws: WebSocket | null = null;
+  private reconnectInterval: number = 5000;
+  private heartbeatInterval: NodeJS.Timeout | null = null;
+  private onTickHandler: TickHandler | null = null;
+
+  constructor(private assets: Asset[]) {}
+
+  /**
+   * Set callback for incoming ticks
+   */
+  onTick(handler: TickHandler) {
+    this.onTickHandler = handler;
+  }
+
+  /**
+   * Connect to Binance WebSocket streams
+   * Multi-stream format: wss://stream.binance.com:9443/stream?streams=btcusdt@ticker/ethusdt@ticker
+   */
+  connect() {
+    const streams = this.assets.map((asset) => `${asset}@ticker`).join('/');
+    const url = `wss://stream.binance.com:9443/stream?streams=${streams}`;
+
+    console.log(`Connecting to Binance WebSocket: ${url}`);
+
+    this.ws = new WebSocket(url);
+
+    this.ws.on('open', () => {
+      console.log('Binance WebSocket connected');
+      this.startHeartbeat();
+    });
+
+    this.ws.on('message', async (data: WebSocket.Data) => {
+      try {
+        const message = JSON.parse(data.toString());
+        await this.handleMessage(message);
+      } catch (error) {
+        console.error('Error parsing WebSocket message:', error);
+      }
+    });
+
+    this.ws.on('error', (error: Error) => {
+      console.error('Binance WebSocket error:', error);
+    });
+
+    this.ws.on('close', () => {
+      console.log('Binance WebSocket closed. Reconnecting...');
+      this.stopHeartbeat();
+      setTimeout(() => this.connect(), this.reconnectInterval);
+    });
+  }
+
+  /**
+   * Handle incoming ticker messages
+   */
+  private async handleMessage(message: { stream?: string; data?: any }) {
+    if (message.stream && message.data) {
+      const ticker = message.data;
+      const asset = ticker.s.toLowerCase(); // btcusdt, ethusdt, etc.
+
+      const tickData: TickData = {
+        asset,
+        price: parseFloat(ticker.c),      // Current price
+        volume: parseFloat(ticker.v),     // 24h volume
+        timestamp: ticker.E,              // Event time (Unix ms)
+        high24h: parseFloat(ticker.h),    // 24h high
+        low24h: parseFloat(ticker.l),     // 24h low
+        change24h: parseFloat(ticker.P),  // Price change percentage
+      };
+
+      // Call the tick handler if set
+      if (this.onTickHandler) {
+        await this.onTickHandler(tickData);
+      }
+    }
+  }
+
+  /**
+   * Keep connection alive with heartbeat (ping every 30s)
+   */
+  private startHeartbeat() {
+    this.heartbeatInterval = setInterval(() => {
+      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+        this.ws.ping();
+      }
+    }, 30000);
+  }
+
+  private stopHeartbeat() {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+  }
+
+  /**
+   * Disconnect from WebSocket
+   */
+  disconnect() {
+    this.stopHeartbeat();
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  /**
+   * Check if connected
+   */
+  isConnected(): boolean {
+    return this.ws !== null && this.ws.readyState === WebSocket.OPEN;
+  }
+}
+
+/**
+ * Singleton instance for WebSocket connection
+ */
+let binanceWSClient: BinanceWebSocketClient | null = null;
+
+export function getBinanceWSClient(assets: Asset[] = ['btcusdt', 'ethusdt']) {
+  if (!binanceWSClient) {
+    binanceWSClient = new BinanceWebSocketClient(assets);
+  }
+  return binanceWSClient;
+}
+
+export { BinanceWebSocketClient };
+```
+
+### Usage Example
+
+```typescript
+import { getBinanceWSClient, type TickData } from './binance-websocket';
+
+const client = getBinanceWSClient(['btcusdt', 'ethusdt', 'solusdt']);
+
+client.onTick(async (tick: TickData) => {
+  console.log(`${tick.asset}: $${tick.price} (${tick.change24h > 0 ? '+' : ''}${tick.change24h.toFixed(2)}%)`);
+
+  // Store in database, cache in Redis, etc.
+});
+
+client.connect();
+
+// Graceful shutdown
+process.on('SIGINT', () => {
+  client.disconnect();
+  process.exit();
+});
+```
+
+---
+
+## 2. Historical Data via REST API
+
+### binance-rest.ts
+
+```typescript
+export type Interval = '1m' | '5m' | '15m' | '1h' | '4h' | '1d';
+
+export interface Candle {
+  timestamp: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface FetchHistoricalOptions {
+  symbol: string;
+  interval?: Interval;
+  limit?: number;
+  startTime?: number;  // Unix milliseconds
+  endTime?: number;    // Unix milliseconds
+}
+
+/**
+ * Fetch historical OHLCV data from Binance REST API
+ *
+ * @param options - Fetch options or symbol string
+ * @returns Array of candle objects
+ *
+ * Binance API limits:
+ * - Max 1000 candles per request
+ * - No authentication required for market data
+ * - Rate limit: 1200 requests/minute
+ */
+export async function fetchHistoricalCandles(
+  symbolOrOptions: string | FetchHistoricalOptions,
+  interval: Interval = '1m',
+  limit: number = 1000,
+  endTime?: number
+): Promise<Candle[]> {
+  // Support both old signature and new options object
+  let options: FetchHistoricalOptions;
+  if (typeof symbolOrOptions === 'string') {
+    options = { symbol: symbolOrOptions, interval, limit, endTime };
+  } else {
+    options = symbolOrOptions;
+  }
+
+  const {
+    symbol,
+    interval: intv = '1m',
+    limit: lim = 1000,
+    startTime,
+    endTime: end,
+  } = options;
+
+  const params = new URLSearchParams({
+    symbol: symbol.toUpperCase(),
+    interval: intv,
+    limit: String(Math.min(lim, 1000)), // Binance max is 1000
+  });
+
+  if (startTime) {
+    params.append('startTime', String(startTime));
+  }
+
+  if (end) {
+    params.append('endTime', String(end));
+  }
+
+  const url = `https://api.binance.com/api/v3/klines?${params.toString()}`;
+
+  const response = await fetch(url);
+  const data = await response.json();
+
+  // Handle Binance API errors
+  if (data.code && data.msg) {
+    throw new Error(`Binance API error: ${data.msg}`);
+  }
+
+  // Transform Binance response to Candle objects
+  // Binance returns: [openTime, open, high, low, close, volume, closeTime, ...]
+  return data.map((candle: (string | number)[]) => ({
+    timestamp: new Date(candle[0] as number).toISOString(),
+    open: parseFloat(candle[1] as string),
+    high: parseFloat(candle[2] as string),
+    low: parseFloat(candle[3] as string),
+    close: parseFloat(candle[4] as string),
+    volume: parseFloat(candle[5] as string),
+  }));
+}
+
+/**
+ * Fetch large date range by paginating through Binance API
+ *
+ * @param symbol - Trading pair (e.g., 'btcusdt')
+ * @param interval - Candle interval
+ * @param startDate - Start date
+ * @param endDate - End date
+ * @returns Array of all candles in range
+ */
+export async function fetchDateRange(
+  symbol: string,
+  interval: Interval,
+  startDate: Date,
+  endDate: Date
+): Promise<Candle[]> {
+  const allCandles: Candle[] = [];
+  let currentStart = startDate.getTime();
+  const endTime = endDate.getTime();
+
+  // Calculate interval in milliseconds for pagination
+  const intervalMs: Record<Interval, number> = {
+    '1m': 60000,
+    '5m': 300000,
+    '15m': 900000,
+    '1h': 3600000,
+    '4h': 14400000,
+    '1d': 86400000,
+  };
+
+  while (currentStart < endTime) {
+    console.log(`Fetching from ${new Date(currentStart).toISOString()}...`);
+
+    const candles = await fetchHistoricalCandles({
+      symbol,
+      interval,
+      limit: 1000,
+      startTime: currentStart,
+      endTime: endTime,
+    });
+
+    if (candles.length === 0) break;
+
+    allCandles.push(...candles);
+
+    // Move start to after last candle
+    const lastTimestamp = new Date(candles[candles.length - 1].timestamp).getTime();
+    currentStart = lastTimestamp + intervalMs[interval];
+
+    // Rate limiting: 100ms delay between requests
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  return allCandles;
+}
+```
+
+### Usage Example
+
+```typescript
+import { fetchHistoricalCandles, fetchDateRange } from './binance-rest';
+
+// Simple fetch
+const candles = await fetchHistoricalCandles('btcusdt', '1h', 100);
+console.log(`Fetched ${candles.length} candles`);
+console.log(`Latest price: $${candles[0].close}`);
+
+// Fetch date range
+const historicalData = await fetchDateRange(
+  'btcusdt',
+  '1h',
+  new Date('2025-01-01'),
+  new Date('2025-12-01')
+);
+console.log(`Total candles: ${historicalData.length}`);
+```
+
+---
+
+## 3. Bulk Download from Binance Data Portal
+
+Binance provides pre-packaged CSV files at https://data.binance.vision - much faster for large datasets.
+
+### binance-bulk-download.ts
+
+```typescript
+import { createWriteStream, mkdirSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import https from 'https';
+
+export interface Candle {
+  timestamp: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+/**
+ * Download a file from URL
+ */
+async function downloadFile(url: string, destPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const file = createWriteStream(destPath);
+    https.get(url, (response) => {
+      if (response.statusCode === 200) {
+        response.pipe(file);
+        file.on('finish', () => {
+          file.close();
+          resolve(true);
+        });
+      } else {
+        file.close();
+        resolve(false);
+      }
+    }).on('error', () => {
+      file.close();
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Convert Binance timestamp to ISO string
+ * Binance Data Portal uses microseconds (16 digits), API uses milliseconds (13 digits)
+ */
+function convertUnixToISO(unix: number): string {
+  const unixMs = unix > 9999999999999 ? Math.floor(unix / 1000) : unix;
+  return new Date(unixMs).toISOString();
+}
+
+/**
+ * Parse Binance CSV file to candle objects
+ *
+ * Binance CSV format:
+ * open_time,open,high,low,close,volume,close_time,quote_volume,count,taker_buy_volume,taker_buy_quote_volume,ignore
+ */
+export function parseBinanceCSV(filePath: string): Candle[] {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n').filter(line => line.trim());
+
+  // Skip header if present (check if first field is numeric)
+  const startIndex = isNaN(parseInt(lines[0].split(',')[0])) ? 1 : 0;
+  const dataLines = lines.slice(startIndex);
+
+  return dataLines.map(line => {
+    const parts = line.split(',');
+    const [open_time, open, high, low, close, volume] = parts;
+    return {
+      timestamp: convertUnixToISO(parseInt(open_time)),
+      open: parseFloat(open),
+      high: parseFloat(high),
+      low: parseFloat(low),
+      close: parseFloat(close),
+      volume: parseFloat(volume),
+    };
+  });
+}
+
+export interface BulkDownloadOptions {
+  symbol: string;
+  interval: string;
+  startDate: string;  // YYYY-MM-DD
+  endDate: string;    // YYYY-MM-DD
+  outputDir?: string;
+}
+
+/**
+ * Bulk download historical data from Binance Data Portal
+ *
+ * Downloads monthly and daily archives, extracts them, and parses to candles.
+ * Much faster than REST API for large datasets.
+ */
+export async function bulkDownload(options: BulkDownloadOptions): Promise<Candle[]> {
+  const {
+    symbol,
+    interval,
+    startDate,
+    endDate,
+    outputDir = `./data/binance/${symbol.toLowerCase()}/${interval}`,
+  } = options;
+
+  const symbolUpper = symbol.toUpperCase();
+  const baseUrl = 'https://data.binance.vision/data/spot';
+
+  // Create output directory
+  mkdirSync(outputDir, { recursive: true });
+
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  const downloadedFiles: string[] = [];
+
+  // 1. Download monthly archives
+  console.log('Downloading monthly archives...');
+  let currentDate = new Date(start.getFullYear(), start.getMonth(), 1);
+
+  while (currentDate <= end) {
+    const year = currentDate.getFullYear();
+    const month = String(currentDate.getMonth() + 1).padStart(2, '0');
+    const filename = `${symbolUpper}-${interval}-${year}-${month}.zip`;
+    const url = `${baseUrl}/monthly/klines/${symbolUpper}/${interval}/${filename}`;
+    const destPath = join(outputDir, filename);
+
+    process.stdout.write(`  ${filename}...`);
+    const success = await downloadFile(url, destPath);
+    console.log(success ? ' ✓' : ' not available');
+
+    if (success) {
+      downloadedFiles.push(destPath);
+    }
+
+    // Next month
+    currentDate.setMonth(currentDate.getMonth() + 1);
+  }
+
+  // 2. Download daily files for the end month (may not be in monthly archive yet)
+  console.log('\nDownloading daily files...');
+  const endYear = end.getFullYear();
+  const endMonth = String(end.getMonth() + 1).padStart(2, '0');
+
+  for (let day = 1; day <= end.getDate(); day++) {
+    const dayStr = String(day).padStart(2, '0');
+    const filename = `${symbolUpper}-${interval}-${endYear}-${endMonth}-${dayStr}.zip`;
+    const url = `${baseUrl}/daily/klines/${symbolUpper}/${interval}/${filename}`;
+    const destPath = join(outputDir, filename);
+
+    process.stdout.write(`  ${filename}...`);
+    const success = await downloadFile(url, destPath);
+    console.log(success ? ' ✓' : ' not available');
+
+    if (success) {
+      downloadedFiles.push(destPath);
+    }
+  }
+
+  if (downloadedFiles.length === 0) {
+    throw new Error('No files downloaded');
+  }
+
+  // 3. Extract all ZIP files
+  console.log('\nExtracting archives...');
+  for (const zipPath of downloadedFiles) {
+    try {
+      execSync(`unzip -o -q "${zipPath}" -d "${outputDir}"`, { stdio: 'pipe' });
+    } catch {
+      // Ignore extraction errors for individual files
+    }
+  }
+
+  // 4. Find and parse all CSV files
+  const csvFiles = readdirSync(outputDir)
+    .filter(f => f.endsWith('.csv') && !f.includes('-converted'))
+    .sort();
+
+  console.log(`\nParsing ${csvFiles.length} CSV files...`);
+
+  let allCandles: Candle[] = [];
+  for (const csvFile of csvFiles) {
+    const candles = parseBinanceCSV(join(outputDir, csvFile));
+    allCandles.push(...candles);
+  }
+
+  // 5. Sort and deduplicate
+  allCandles.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  const uniqueCandles = allCandles.filter((c, i, arr) =>
+    i === 0 || c.timestamp !== arr[i - 1].timestamp
+  );
+
+  // 6. Filter to exact date range
+  const startTime = new Date(startDate).toISOString();
+  const endTime = new Date(endDate + 'T23:59:59Z').toISOString();
+
+  const filteredCandles = uniqueCandles.filter(c =>
+    c.timestamp >= startTime && c.timestamp <= endTime
+  );
+
+  console.log(`\nTotal unique candles: ${filteredCandles.length}`);
+
+  return filteredCandles;
+}
+```
+
+### Usage Example
+
+```typescript
+import { bulkDownload } from './binance-bulk-download';
+
+const candles = await bulkDownload({
+  symbol: 'btcusdt',
+  interval: '5m',
+  startDate: '2025-01-01',
+  endDate: '2025-06-30',
+});
+
+console.log(`Downloaded ${candles.length} candles`);
+console.log(`Range: ${candles[0].timestamp} to ${candles[candles.length - 1].timestamp}`);
+```
+
+---
+
+## 4. Redis Caching
+
+### redis-cache.ts
+
+```typescript
+import { Redis } from '@upstash/redis';
+
+// Initialize Upstash Redis client
+// For traditional Redis, use 'ioredis' package instead
+export const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+/**
+ * Cache keys structure
+ */
+export const cacheKeys = {
+  marketLatest: (asset: string) => `market:${asset}:latest`,
+  market1m: (asset: string, timestamp: number) => `market:${asset}:1m:${timestamp}`,
+};
+
+export interface MarketTick {
+  price: number;
+  volume: number;
+  timestamp: number;
+}
+
+/**
+ * Cache a market tick with 60 second TTL
+ */
+export async function cacheMarketTick(asset: string, data: MarketTick): Promise<void> {
+  const key = cacheKeys.marketLatest(asset);
+  await redis.set(key, JSON.stringify(data), { ex: 60 });
+}
+
+/**
+ * Get cached market tick
+ */
+export async function getCachedMarketTick(asset: string): Promise<MarketTick | null> {
+  const key = cacheKeys.marketLatest(asset);
+  const data = await redis.get<string>(key);
+  return data ? JSON.parse(data) : null;
+}
+```
+
+### Integrate with WebSocket
+
+```typescript
+import { getBinanceWSClient } from './binance-websocket';
+import { cacheMarketTick } from './redis-cache';
+
+const client = getBinanceWSClient(['btcusdt', 'ethusdt']);
+
+client.onTick(async (tick) => {
+  // Cache in Redis for fast access
+  await cacheMarketTick(tick.asset, {
+    price: tick.price,
+    volume: tick.volume,
+    timestamp: tick.timestamp,
+  });
+});
+
+client.connect();
+```
+
+---
+
+## 5. Server-Sent Events (SSE) for Browser
+
+### sse-stream.ts (Next.js API Route)
+
+```typescript
+import { getCachedMarketTick } from './redis-cache';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * SSE endpoint for real-time market data streaming
+ *
+ * Usage in browser:
+ *   const source = new EventSource('/api/stream?assets=btcusdt,ethusdt')
+ *   source.onmessage = (e) => console.log(JSON.parse(e.data))
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const assetsParam = searchParams.get('assets') || 'btcusdt,ethusdt';
+  const assets = assetsParam.split(',').map(a => a.trim().toLowerCase());
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      let isActive = true;
+
+      // Send initial connection message
+      const initialData = `data: ${JSON.stringify({
+        type: 'connected',
+        assets,
+        timestamp: new Date().toISOString()
+      })}\n\n`;
+      controller.enqueue(encoder.encode(initialData));
+
+      // Store last known prices to detect changes
+      const lastPrices = new Map<string, number>();
+
+      // Poll Redis every 1 second
+      const poller = setInterval(async () => {
+        if (!isActive) {
+          clearInterval(poller);
+          return;
+        }
+
+        try {
+          for (const asset of assets) {
+            const tickData = await getCachedMarketTick(asset);
+            if (!tickData) continue;
+
+            // Only send if price changed
+            const lastPrice = lastPrices.get(asset);
+            if (lastPrice !== tickData.price) {
+              lastPrices.set(asset, tickData.price);
+
+              const sseMessage = `data: ${JSON.stringify({
+                type: 'ticker',
+                asset,
+                ...tickData,
+                timestamp: new Date().toISOString()
+              })}\n\n`;
+              controller.enqueue(encoder.encode(sseMessage));
+            }
+          }
+        } catch (error) {
+          console.error('Error polling market data:', error);
+        }
+      }, 1000);
+
+      // Heartbeat every 30 seconds
+      const heartbeat = setInterval(() => {
+        if (!isActive) {
+          clearInterval(heartbeat);
+          return;
+        }
+
+        const heartbeatMessage = `data: ${JSON.stringify({
+          type: 'heartbeat',
+          timestamp: new Date().toISOString()
+        })}\n\n`;
+        controller.enqueue(encoder.encode(heartbeatMessage));
+      }, 30000);
+
+      // Cleanup on disconnect
+      request.signal.addEventListener('abort', () => {
+        isActive = false;
+        clearInterval(poller);
+        clearInterval(heartbeat);
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no', // Disable buffering for Nginx
+    },
+  });
+}
+```
+
+### Browser Client
+
+```typescript
+// React hook for SSE
+import { useEffect, useState } from 'react';
+
+interface TickerData {
+  asset: string;
+  price: number;
+  volume: number;
+  timestamp: string;
+}
+
+export function useMarketStream(assets: string[]) {
+  const [tickers, setTickers] = useState<Map<string, TickerData>>(new Map());
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    const assetsParam = assets.join(',');
+    const source = new EventSource(`/api/stream?assets=${assetsParam}`);
+
+    source.onopen = () => setIsConnected(true);
+
+    source.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+
+      if (data.type === 'ticker') {
+        setTickers(prev => {
+          const next = new Map(prev);
+          next.set(data.asset, data);
+          return next;
+        });
+      }
+    };
+
+    source.onerror = () => setIsConnected(false);
+
+    return () => source.close();
+  }, [assets.join(',')]);
+
+  return { tickers, isConnected };
+}
+
+// Usage
+function PriceDisplay() {
+  const { tickers, isConnected } = useMarketStream(['btcusdt', 'ethusdt']);
+
+  return (
+    <div>
+      <p>Status: {isConnected ? 'Connected' : 'Disconnected'}</p>
+      {Array.from(tickers.values()).map(ticker => (
+        <p key={ticker.asset}>
+          {ticker.asset.toUpperCase()}: ${ticker.price.toLocaleString()}
+        </p>
+      ))}
+    </div>
+  );
+}
+```
+
+---
+
+## 6. CLI Commands
+
+### cli/index.ts
+
+```typescript
+#!/usr/bin/env node
+import 'dotenv/config';
+import { Command } from 'commander';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { fetchHistoricalCandles, fetchDateRange } from './binance-rest';
+import { bulkDownload } from './binance-bulk-download';
+
+const program = new Command();
+
+program
+  .name('market-data')
+  .description('CLI for downloading market data from Binance')
+  .version('1.0.0');
+
+/**
+ * Download via REST API (small datasets)
+ */
+program
+  .command('download <symbol>')
+  .description('Download historical data via REST API')
+  .option('-i, --interval <interval>', 'Candle interval', '1m')
+  .option('-l, --limit <limit>', 'Number of candles', '1000')
+  .action(async (symbol, options) => {
+    console.log(`Downloading ${options.limit} ${options.interval} candles for ${symbol}...`);
+
+    const candles = await fetchHistoricalCandles(
+      symbol.toLowerCase(),
+      options.interval,
+      parseInt(options.limit)
+    );
+
+    console.log(`✓ Fetched ${candles.length} candles`);
+    console.log(`Latest price: $${candles[0].close}`);
+
+    // Export to CSV
+    const outputDir = join(process.cwd(), 'data');
+    mkdirSync(outputDir, { recursive: true });
+
+    const csvPath = join(outputDir, `${symbol.toLowerCase()}-${options.interval}.csv`);
+    const csvContent = [
+      'timestamp,open,high,low,close,volume',
+      ...candles.map(c => `${c.timestamp},${c.open},${c.high},${c.low},${c.close},${c.volume}`)
+    ].join('\n');
+
+    writeFileSync(csvPath, csvContent);
+    console.log(`✓ Exported to ${csvPath}`);
+  });
+
+/**
+ * Download date range via REST API
+ */
+program
+  .command('download-range <symbol>')
+  .description('Download historical data for date range')
+  .option('-i, --interval <interval>', 'Candle interval', '1h')
+  .option('-s, --start <date>', 'Start date (YYYY-MM-DD)', '2025-01-01')
+  .option('-e, --end <date>', 'End date (YYYY-MM-DD)', '2025-12-01')
+  .action(async (symbol, options) => {
+    console.log(`Downloading ${symbol} ${options.interval} from ${options.start} to ${options.end}...`);
+
+    const candles = await fetchDateRange(
+      symbol.toLowerCase(),
+      options.interval,
+      new Date(options.start),
+      new Date(options.end)
+    );
+
+    console.log(`✓ Fetched ${candles.length} candles`);
+
+    // Export to CSV
+    const outputDir = join(process.cwd(), 'data');
+    mkdirSync(outputDir, { recursive: true });
+
+    const csvPath = join(outputDir, `${symbol.toLowerCase()}-${options.interval}-${options.start}-to-${options.end}.csv`);
+    const csvContent = [
+      'timestamp,open,high,low,close,volume',
+      ...candles.map(c => `${c.timestamp},${c.open},${c.high},${c.low},${c.close},${c.volume}`)
+    ].join('\n');
+
+    writeFileSync(csvPath, csvContent);
+    console.log(`✓ Exported to ${csvPath}`);
+  });
+
+/**
+ * Bulk download from Binance Data Portal (fastest)
+ */
+program
+  .command('bulk-download <symbol>')
+  .description('Bulk download from Binance Data Portal (fastest)')
+  .option('-i, --interval <interval>', 'Candle interval', '5m')
+  .option('-s, --start <date>', 'Start date (YYYY-MM-DD)', '2025-01-01')
+  .option('-e, --end <date>', 'End date (YYYY-MM-DD)', '2025-06-30')
+  .action(async (symbol, options) => {
+    const candles = await bulkDownload({
+      symbol,
+      interval: options.interval,
+      startDate: options.start,
+      endDate: options.end,
+    });
+
+    // Export merged CSV
+    const outputDir = join(process.cwd(), 'data');
+    const csvPath = join(outputDir, `${symbol.toLowerCase()}-${options.interval}-${options.start}-to-${options.end}.csv`);
+
+    const csvContent = [
+      'timestamp,open,high,low,close,volume',
+      ...candles.map(c => `${c.timestamp},${c.open},${c.high},${c.low},${c.close},${c.volume}`)
+    ].join('\n');
+
+    writeFileSync(csvPath, csvContent);
+    console.log(`✓ Exported to ${csvPath}`);
+  });
+
+program.parse();
+```
+
+### Usage
+
+```bash
+# Quick download via REST API
+pnpm cli download btcusdt -i 1h -l 500
+
+# Download date range
+pnpm cli download-range btcusdt -s 2025-01-01 -e 2025-03-01 -i 1h
+
+# Bulk download (fastest for large datasets)
+pnpm cli bulk-download btcusdt -i 5m -s 2025-01-01 -e 2025-12-01
+```
+
+---
+
+## 7. CSV Conversion Tools
+
+### convert-csv.ts
+
+Convert between Binance CSV format and custom formats.
+
+```typescript
+import { readFileSync, writeFileSync } from 'fs';
+
+/**
+ * Convert Binance CSV to custom format
+ *
+ * Input (Binance):
+ *   open_time,open,high,low,close,volume,close_time,...
+ *   1699833600000,36500.00,36550.00,36480.00,36520.00,1234.56,...
+ *
+ * Output (Custom):
+ *   Timestamp,Symbol,Open,High,Low,Close,Volume
+ *   2024-11-13T00:00:00.000Z,BTCUSDT-PERPETUAL,36500.00,...
+ */
+export function convertBinanceCSV(
+  inputPath: string,
+  symbol: string,
+  outputPath?: string
+): void {
+  console.log(`Converting: ${inputPath}`);
+
+  const input = readFileSync(inputPath, 'utf-8');
+  const lines = input.split('\n').filter(line => line.trim());
+
+  // Skip header if present
+  const startIndex = isNaN(parseInt(lines[0].split(',')[0])) ? 1 : 0;
+  const dataLines = lines.slice(startIndex);
+
+  console.log(`Found ${dataLines.length} candles`);
+
+  // Convert to custom format
+  const header = 'Timestamp,Symbol,Open,High,Low,Close,Volume';
+  const rows = dataLines.map(line => {
+    const parts = line.split(',');
+    const [open_time, open, high, low, close, volume] = parts;
+
+    // Convert timestamp
+    const unix = parseInt(open_time);
+    const unixMs = unix > 9999999999999 ? Math.floor(unix / 1000) : unix;
+    const timestamp = new Date(unixMs).toISOString();
+
+    const symbolName = `${symbol.toUpperCase()}-PERPETUAL`;
+
+    return `${timestamp},${symbolName},${open},${high},${low},${close},${volume}`;
+  });
+
+  const output = [header, ...rows].join('\n');
+
+  // Generate output path if not provided
+  const finalOutputPath = outputPath || inputPath.replace('.csv', '-converted.csv');
+
+  writeFileSync(finalOutputPath, output);
+  console.log(`Converted to: ${finalOutputPath}`);
+}
+
+// CLI usage
+if (require.main === module) {
+  const [inputPath, symbol, outputPath] = process.argv.slice(2);
+
+  if (!inputPath || !symbol) {
+    console.error('Usage: tsx convert-csv.ts <input.csv> <symbol> [output.csv]');
+    process.exit(1);
+  }
+
+  convertBinanceCSV(inputPath, symbol, outputPath);
+}
+```
+
+---
+
+## 8. CSV Merging Tools
+
+Tools for merging multiple CSV files into a single chronologically sorted file.
+
+### merge-csv.ts
+
+```typescript
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+
+interface CandleRow {
+  timestamp: string;
+  line: string;
+}
+
+/**
+ * Merge multiple CSV files into one chronologically sorted file
+ *
+ * @param outputPath - Output file path
+ * @param inputDir - Directory containing CSV files
+ * @param pattern - File pattern to match (e.g., '*-lona.csv')
+ */
+export function mergeCSVFiles(
+  outputPath: string,
+  inputDir: string,
+  pattern: string = '*-lona.csv'
+): void {
+  console.log(`Merging CSV files from: ${inputDir}`);
+
+  // Find all matching files
+  const allFiles = readdirSync(inputDir);
+  const files = allFiles
+    .filter(f => {
+      if (pattern.includes('*')) {
+        const suffix = pattern.replace('*', '');
+        return f.endsWith(suffix);
+      }
+      return f === pattern;
+    })
+    .map(f => join(inputDir, f))
+    .sort();
+
+  if (files.length === 0) {
+    throw new Error('No files found matching pattern');
+  }
+
+  console.log(`Found ${files.length} files to merge`);
+
+  const allRows: CandleRow[] = [];
+  let header = '';
+
+  // Read all files
+  for (const file of files) {
+    console.log(`  Reading: ${file}`);
+    const content = readFileSync(file, 'utf-8');
+    const lines = content.split('\n').filter(line => line.trim());
+
+    // Get header from first file
+    if (!header && lines.length > 0) {
+      header = lines[0];
+    }
+
+    // Add all data rows (skip header)
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i];
+      const timestamp = line.split(',')[0];
+      allRows.push({ timestamp, line });
+    }
+  }
+
+  console.log(`Total rows collected: ${allRows.length}`);
+
+  // Sort by timestamp (ISO strings sort correctly)
+  console.log('Sorting by timestamp...');
+  allRows.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+  // Remove duplicates (same timestamp)
+  const uniqueRows = allRows.filter((row, i, arr) =>
+    i === 0 || row.timestamp !== arr[i - 1].timestamp
+  );
+
+  console.log(`Unique rows after deduplication: ${uniqueRows.length}`);
+
+  // Write merged file
+  const output = header + '\n' + uniqueRows.map(row => row.line).join('\n');
+  writeFileSync(outputPath, output);
+
+  console.log(`\nMerged file created: ${outputPath}`);
+  console.log(`Total candles: ${uniqueRows.length}`);
+  console.log(`Date range: ${uniqueRows[0]?.timestamp} to ${uniqueRows[uniqueRows.length - 1]?.timestamp}`);
+}
+
+// CLI usage
+if (require.main === module) {
+  const [outputPath, inputDir, pattern] = process.argv.slice(2);
+
+  if (!outputPath || !inputDir) {
+    console.error('Usage: tsx merge-csv.ts <output.csv> <input-dir> [pattern]');
+    console.error('Example: tsx merge-csv.ts merged.csv ./data/btcusdt/1m "*-lona.csv"');
+    process.exit(1);
+  }
+
+  mergeCSVFiles(outputPath, inputDir, pattern || '*-lona.csv');
+}
+```
+
+### batch-convert.ts
+
+Convert all Binance CSV files in a directory to your custom format.
+
+```typescript
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Convert Unix timestamp to ISO string
+ * Handles both milliseconds (13 digits) and microseconds (16 digits)
+ */
+function convertUnixToISO(unix: number): string {
+  const unixMs = unix > 9999999999999 ? Math.floor(unix / 1000) : unix;
+  return new Date(unixMs).toISOString();
+}
+
+/**
+ * Convert a single Binance CSV file to custom format
+ */
+function convertCSV(inputPath: string, symbol: string, outputPath: string): number {
+  const input = readFileSync(inputPath, 'utf-8');
+  const lines = input.split('\n').filter(line => line.trim());
+
+  // Skip header if present
+  const startIndex = isNaN(parseInt(lines[0].split(',')[0])) ? 1 : 0;
+  const dataLines = lines.slice(startIndex);
+
+  // Custom format header
+  const header = 'Timestamp,Symbol,Open,High,Low,Close,Volume\n';
+
+  const rows = dataLines.map(line => {
+    const parts = line.split(',');
+    const [open_time, open, high, low, close, volume] = parts;
+    const timestamp = convertUnixToISO(parseInt(open_time));
+    const symbolName = `${symbol.toUpperCase()}-PERPETUAL`;
+    return `${timestamp},${symbolName},${open},${high},${low},${close},${volume}`;
+  }).join('\n');
+
+  writeFileSync(outputPath, header + rows);
+  return dataLines.length;
+}
+
+/**
+ * Batch convert all CSV files in a directory
+ *
+ * @param inputDir - Directory containing Binance CSV files
+ * @param symbol - Trading symbol (e.g., 'btcusdt')
+ */
+export function batchConvert(inputDir: string, symbol: string): void {
+  console.log(`Converting all CSV files in ${inputDir}...`);
+
+  // Find all CSV files (excluding already converted ones)
+  const files = readdirSync(inputDir)
+    .filter(f => f.endsWith('.csv') && !f.endsWith('-lona.csv') && !f.endsWith('-converted.csv'))
+    .sort();
+
+  if (files.length === 0) {
+    console.log('No CSV files found to convert');
+    return;
+  }
+
+  let totalCandles = 0;
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    const inputPath = join(inputDir, file);
+    const outputPath = join(inputDir, file.replace('.csv', '-lona.csv'));
+
+    console.log(`[${i + 1}/${files.length}] ${file}`);
+    const candles = convertCSV(inputPath, symbol, outputPath);
+    totalCandles += candles;
+  }
+
+  console.log(`\nConverted ${files.length} files (${totalCandles.toLocaleString()} candles)`);
+}
+
+// CLI usage
+if (require.main === module) {
+  const [inputDir, symbol] = process.argv.slice(2);
+
+  if (!inputDir) {
+    console.error('Usage: tsx batch-convert.ts <input-dir> [symbol]');
+    console.error('Example: tsx batch-convert.ts ./data/binance/btcusdt/5m btcusdt');
+    process.exit(1);
+  }
+
+  batchConvert(inputDir, symbol || 'btcusdt');
+}
+```
+
+### merge-specific-files.ts
+
+Merge specific files (useful for weekly/monthly merges).
+
+```typescript
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+
+interface CandleRow {
+  timestamp: string;
+  line: string;
+}
+
+/**
+ * Merge specific CSV files into one
+ *
+ * @param files - Array of file paths to merge
+ * @param outputPath - Output file path
+ */
+export function mergeSpecificFiles(files: string[], outputPath: string): void {
+  console.log(`Merging ${files.length} files -> ${outputPath}`);
+
+  const allRows: CandleRow[] = [];
+  let header = '';
+
+  for (const file of files) {
+    if (!existsSync(file)) {
+      console.log(`  Skipping (not found): ${file}`);
+      continue;
+    }
+
+    console.log(`  Reading: ${file}`);
+    const content = readFileSync(file, 'utf-8');
+    const lines = content.split('\n').filter(line => line.trim());
+
+    // Get header from first file
+    if (!header && lines.length > 0) {
+      header = lines[0];
+    }
+
+    // Add all data rows
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i];
+      const timestamp = line.split(',')[0];
+      allRows.push({ timestamp, line });
+    }
+  }
+
+  console.log(`Total rows: ${allRows.length}`);
+
+  // Sort by timestamp
+  allRows.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+  // Remove duplicates
+  const uniqueRows = allRows.filter((row, i, arr) =>
+    i === 0 || row.timestamp !== arr[i - 1].timestamp
+  );
+
+  const output = header + '\n' + uniqueRows.map(row => row.line).join('\n');
+  writeFileSync(outputPath, output);
+
+  console.log(`Created: ${outputPath}`);
+  console.log(`Range: ${uniqueRows[0]?.timestamp} to ${uniqueRows[uniqueRows.length - 1]?.timestamp}`);
+}
+
+// Example: Merge a week of daily files
+const weeklyFiles = [
+  'data/binance/btcusdt/5m/BTCUSDT-5m-2025-11-23-lona.csv',
+  'data/binance/btcusdt/5m/BTCUSDT-5m-2025-11-24-lona.csv',
+  'data/binance/btcusdt/5m/BTCUSDT-5m-2025-11-25-lona.csv',
+  'data/binance/btcusdt/5m/BTCUSDT-5m-2025-11-26-lona.csv',
+  'data/binance/btcusdt/5m/BTCUSDT-5m-2025-11-27-lona.csv',
+  'data/binance/btcusdt/5m/BTCUSDT-5m-2025-11-28-lona.csv',
+  'data/binance/btcusdt/5m/BTCUSDT-5m-2025-11-29-lona.csv',
+];
+
+mergeSpecificFiles(weeklyFiles, 'data/binance/btcusdt/5m/BTCUSDT-5m-2025-11-23-to-29-lona.csv');
+```
+
+### CLI Commands for Merging
+
+Add these to your CLI:
+
+```typescript
+program
+  .command('merge <output>')
+  .description('Merge multiple CSV files into one')
+  .option('-d, --dir <directory>', 'Directory containing CSV files', './data')
+  .option('-p, --pattern <pattern>', 'File pattern to match', '*-lona.csv')
+  .action((output, options) => {
+    mergeCSVFiles(output, options.dir, options.pattern);
+  });
+
+program
+  .command('batch-convert')
+  .description('Convert all Binance CSV files in a directory')
+  .option('-d, --dir <directory>', 'Directory containing CSV files', './data')
+  .option('-s, --symbol <symbol>', 'Trading symbol', 'btcusdt')
+  .action((options) => {
+    batchConvert(options.dir, options.symbol);
+  });
+```
+
+### Usage Examples
+
+```bash
+# Convert all Binance CSVs in a directory
+pnpm tsx batch-convert.ts ./data/binance/btcusdt/5m btcusdt
+
+# Merge all converted files
+pnpm tsx merge-csv.ts ./data/merged.csv ./data/binance/btcusdt/5m "*-lona.csv"
+
+# Using CLI
+pnpm cli batch-convert -d ./data/binance/btcusdt/5m -s btcusdt
+pnpm cli merge ./data/merged.csv -d ./data/binance/btcusdt/5m -p "*-lona.csv"
+```
+
+---
+
+## 9. Data Adaptation & Transformation
+
+Tools for transforming data between formats and resampling timeframes.
+
+### Timeframe Resampling
+
+Convert lower timeframe data to higher timeframes (e.g., 1m → 5m → 1h).
+
+```typescript
+import { readFileSync, writeFileSync } from 'fs';
+
+interface Candle {
+  timestamp: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+/**
+ * Resample candles to a higher timeframe
+ *
+ * @param candles - Input candles (sorted by timestamp ascending)
+ * @param targetIntervalMs - Target interval in milliseconds
+ * @returns Resampled candles
+ *
+ * Example: 1m candles -> 5m candles (targetIntervalMs = 300000)
+ */
+export function resampleCandles(
+  candles: Candle[],
+  targetIntervalMs: number
+): Candle[] {
+  if (candles.length === 0) return [];
+
+  const resampled: Candle[] = [];
+  let currentBucket: Candle[] = [];
+  let currentBucketStart = 0;
+
+  for (const candle of candles) {
+    const candleTime = new Date(candle.timestamp).getTime();
+
+    // Calculate which bucket this candle belongs to
+    const bucketStart = Math.floor(candleTime / targetIntervalMs) * targetIntervalMs;
+
+    if (currentBucketStart === 0) {
+      currentBucketStart = bucketStart;
+    }
+
+    if (bucketStart !== currentBucketStart && currentBucket.length > 0) {
+      // Aggregate current bucket
+      resampled.push(aggregateBucket(currentBucket, currentBucketStart));
+      currentBucket = [];
+      currentBucketStart = bucketStart;
+    }
+
+    currentBucket.push(candle);
+  }
+
+  // Don't forget the last bucket
+  if (currentBucket.length > 0) {
+    resampled.push(aggregateBucket(currentBucket, currentBucketStart));
+  }
+
+  return resampled;
+}
+
+/**
+ * Aggregate multiple candles into a single OHLCV candle
+ */
+function aggregateBucket(candles: Candle[], bucketStartMs: number): Candle {
+  return {
+    timestamp: new Date(bucketStartMs).toISOString(),
+    open: candles[0].open,                                    // First open
+    high: Math.max(...candles.map(c => c.high)),              // Highest high
+    low: Math.min(...candles.map(c => c.low)),                // Lowest low
+    close: candles[candles.length - 1].close,                 // Last close
+    volume: candles.reduce((sum, c) => sum + c.volume, 0),    // Sum of volumes
+  };
+}
+
+// Interval constants in milliseconds
+export const INTERVALS = {
+  '1m': 60 * 1000,
+  '5m': 5 * 60 * 1000,
+  '15m': 15 * 60 * 1000,
+  '30m': 30 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
+  '4h': 4 * 60 * 60 * 1000,
+  '1d': 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Resample CSV file to a different timeframe
+ */
+export function resampleCSVFile(
+  inputPath: string,
+  outputPath: string,
+  targetInterval: keyof typeof INTERVALS
+): void {
+  console.log(`Resampling ${inputPath} to ${targetInterval}...`);
+
+  const content = readFileSync(inputPath, 'utf-8');
+  const lines = content.split('\n').filter(line => line.trim());
+
+  // Parse header
+  const header = lines[0];
+  const hasSymbol = header.includes('Symbol');
+
+  // Parse candles
+  const candles: Candle[] = [];
+  let symbol = '';
+
+  for (let i = 1; i < lines.length; i++) {
+    const parts = lines[i].split(',');
+
+    if (hasSymbol) {
+      // Format: Timestamp,Symbol,Open,High,Low,Close,Volume
+      const [timestamp, sym, open, high, low, close, volume] = parts;
+      symbol = sym;
+      candles.push({
+        timestamp,
+        open: parseFloat(open),
+        high: parseFloat(high),
+        low: parseFloat(low),
+        close: parseFloat(close),
+        volume: parseFloat(volume),
+      });
+    } else {
+      // Format: timestamp,open,high,low,close,volume
+      const [timestamp, open, high, low, close, volume] = parts;
+      candles.push({
+        timestamp,
+        open: parseFloat(open),
+        high: parseFloat(high),
+        low: parseFloat(low),
+        close: parseFloat(close),
+        volume: parseFloat(volume),
+      });
+    }
+  }
+
+  console.log(`Input candles: ${candles.length}`);
+
+  // Resample
+  const resampled = resampleCandles(candles, INTERVALS[targetInterval]);
+
+  console.log(`Output candles: ${resampled.length}`);
+
+  // Write output
+  let output: string;
+  if (hasSymbol) {
+    output = 'Timestamp,Symbol,Open,High,Low,Close,Volume\n' +
+      resampled.map(c =>
+        `${c.timestamp},${symbol},${c.open},${c.high},${c.low},${c.close},${c.volume}`
+      ).join('\n');
+  } else {
+    output = 'timestamp,open,high,low,close,volume\n' +
+      resampled.map(c =>
+        `${c.timestamp},${c.open},${c.high},${c.low},${c.close},${c.volume}`
+      ).join('\n');
+  }
+
+  writeFileSync(outputPath, output);
+  console.log(`Created: ${outputPath}`);
+}
+
+// CLI usage
+if (require.main === module) {
+  const [inputPath, outputPath, interval] = process.argv.slice(2);
+
+  if (!inputPath || !outputPath || !interval) {
+    console.error('Usage: tsx resample.ts <input.csv> <output.csv> <interval>');
+    console.error('Intervals: 1m, 5m, 15m, 30m, 1h, 4h, 1d');
+    console.error('Example: tsx resample.ts btcusdt-1m.csv btcusdt-1h.csv 1h');
+    process.exit(1);
+  }
+
+  resampleCSVFile(inputPath, outputPath, interval as keyof typeof INTERVALS);
+}
+```
+
+### Format Adapters
+
+Convert between different CSV formats.
+
+```typescript
+import { readFileSync, writeFileSync } from 'fs';
+
+/**
+ * CSV Format Definitions
+ */
+export const CSV_FORMATS = {
+  // Binance Data Portal format
+  binance: {
+    hasHeader: false,  // No header row
+    columns: ['open_time', 'open', 'high', 'low', 'close', 'volume', 'close_time', 'quote_volume', 'count', 'taker_buy_volume', 'taker_buy_quote_volume', 'ignore'],
+    timestampIndex: 0,
+    timestampType: 'unix_ms',  // milliseconds or microseconds
+  },
+
+  // Standard OHLCV format
+  standard: {
+    hasHeader: true,
+    columns: ['timestamp', 'open', 'high', 'low', 'close', 'volume'],
+    timestampIndex: 0,
+    timestampType: 'iso',
+  },
+
+  // Custom Lona format
+  lona: {
+    hasHeader: true,
+    columns: ['Timestamp', 'Symbol', 'Open', 'High', 'Low', 'Close', 'Volume'],
+    timestampIndex: 0,
+    timestampType: 'iso',
+  },
+
+  // TradingView format
+  tradingview: {
+    hasHeader: true,
+    columns: ['time', 'open', 'high', 'low', 'close', 'volume'],
+    timestampIndex: 0,
+    timestampType: 'unix_seconds',
+  },
+};
+
+export type FormatName = keyof typeof CSV_FORMATS;
+
+interface ConvertOptions {
+  inputPath: string;
+  outputPath: string;
+  inputFormat: FormatName;
+  outputFormat: FormatName;
+  symbol?: string;  // Required for 'lona' output format
+}
+
+/**
+ * Convert CSV between formats
+ */
+export function convertFormat(options: ConvertOptions): void {
+  const { inputPath, outputPath, inputFormat, outputFormat, symbol } = options;
+
+  console.log(`Converting ${inputFormat} -> ${outputFormat}`);
+  console.log(`Input: ${inputPath}`);
+
+  const content = readFileSync(inputPath, 'utf-8');
+  const lines = content.split('\n').filter(line => line.trim());
+
+  const inFmt = CSV_FORMATS[inputFormat];
+  const outFmt = CSV_FORMATS[outputFormat];
+
+  // Skip header if input has one
+  const dataStartIndex = inFmt.hasHeader ? 1 : 0;
+  const dataLines = lines.slice(dataStartIndex);
+
+  console.log(`Processing ${dataLines.length} rows...`);
+
+  // Parse and convert each row
+  const outputRows: string[] = [];
+
+  for (const line of dataLines) {
+    const parts = line.split(',');
+
+    // Extract OHLCV data based on input format
+    let timestamp: string;
+    let open: string, high: string, low: string, close: string, volume: string;
+
+    if (inputFormat === 'binance') {
+      const rawTimestamp = parseInt(parts[0]);
+      // Handle both milliseconds and microseconds
+      const unixMs = rawTimestamp > 9999999999999 ? Math.floor(rawTimestamp / 1000) : rawTimestamp;
+      timestamp = new Date(unixMs).toISOString();
+      [, open, high, low, close, volume] = parts;
+    } else if (inputFormat === 'tradingview') {
+      timestamp = new Date(parseInt(parts[0]) * 1000).toISOString();
+      [, open, high, low, close, volume] = parts;
+    } else if (inputFormat === 'lona') {
+      [timestamp, , open, high, low, close, volume] = parts;
+    } else {
+      [timestamp, open, high, low, close, volume] = parts;
+    }
+
+    // Format output based on output format
+    let outputRow: string;
+
+    if (outputFormat === 'lona') {
+      if (!symbol) throw new Error('Symbol required for lona format');
+      outputRow = `${timestamp},${symbol.toUpperCase()}-PERPETUAL,${open},${high},${low},${close},${volume}`;
+    } else if (outputFormat === 'tradingview') {
+      const unixSeconds = Math.floor(new Date(timestamp).getTime() / 1000);
+      outputRow = `${unixSeconds},${open},${high},${low},${close},${volume}`;
+    } else if (outputFormat === 'binance') {
+      const unixMs = new Date(timestamp).getTime();
+      outputRow = `${unixMs},${open},${high},${low},${close},${volume},0,0,0,0,0,0`;
+    } else {
+      outputRow = `${timestamp},${open},${high},${low},${close},${volume}`;
+    }
+
+    outputRows.push(outputRow);
+  }
+
+  // Add header if output format requires it
+  let output: string;
+  if (outFmt.hasHeader) {
+    const header = outFmt.columns.join(',');
+    output = header + '\n' + outputRows.join('\n');
+  } else {
+    output = outputRows.join('\n');
+  }
+
+  writeFileSync(outputPath, output);
+  console.log(`Created: ${outputPath}`);
+  console.log(`Rows: ${outputRows.length}`);
+}
+
+// CLI usage
+if (require.main === module) {
+  const args = process.argv.slice(2);
+
+  if (args.length < 4) {
+    console.error('Usage: tsx format-adapter.ts <input.csv> <output.csv> <input-format> <output-format> [symbol]');
+    console.error('Formats: binance, standard, lona, tradingview');
+    console.error('Example: tsx format-adapter.ts binance.csv lona.csv binance lona btcusdt');
+    process.exit(1);
+  }
+
+  const [inputPath, outputPath, inputFormat, outputFormat, symbol] = args;
+
+  convertFormat({
+    inputPath,
+    outputPath,
+    inputFormat: inputFormat as FormatName,
+    outputFormat: outputFormat as FormatName,
+    symbol,
+  });
+}
+```
+
+### Data Validation
+
+Validate CSV data integrity.
+
+```typescript
+import { readFileSync } from 'fs';
+
+interface ValidationResult {
+  isValid: boolean;
+  totalRows: number;
+  errors: string[];
+  warnings: string[];
+  gaps: Array<{ from: string; to: string; expectedCount: number }>;
+}
+
+/**
+ * Validate OHLCV CSV data
+ *
+ * Checks for:
+ * - Missing/invalid values
+ * - Timestamp gaps
+ * - OHLC consistency (high >= low, etc.)
+ * - Chronological order
+ */
+export function validateCSV(
+  filePath: string,
+  expectedIntervalMs: number
+): ValidationResult {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n').filter(line => line.trim());
+
+  const result: ValidationResult = {
+    isValid: true,
+    totalRows: 0,
+    errors: [],
+    warnings: [],
+    gaps: [],
+  };
+
+  // Skip header
+  const dataLines = lines.slice(1);
+  result.totalRows = dataLines.length;
+
+  let prevTimestamp: number | null = null;
+
+  for (let i = 0; i < dataLines.length; i++) {
+    const lineNum = i + 2; // Account for header and 0-index
+    const parts = dataLines[i].split(',');
+
+    // Extract values (handle both formats)
+    const hasSymbol = parts.length >= 7;
+    const [timestampStr, , openStr, highStr, lowStr, closeStr, volumeStr] = hasSymbol
+      ? parts
+      : [parts[0], '', parts[1], parts[2], parts[3], parts[4], parts[5]];
+
+    // Validate timestamp
+    const timestamp = new Date(timestampStr).getTime();
+    if (isNaN(timestamp)) {
+      result.errors.push(`Line ${lineNum}: Invalid timestamp "${timestampStr}"`);
+      result.isValid = false;
+      continue;
+    }
+
+    // Check chronological order
+    if (prevTimestamp !== null && timestamp < prevTimestamp) {
+      result.errors.push(`Line ${lineNum}: Timestamp out of order`);
+      result.isValid = false;
+    }
+
+    // Check for gaps
+    if (prevTimestamp !== null) {
+      const gap = timestamp - prevTimestamp;
+      if (gap > expectedIntervalMs * 1.5) {
+        const expectedCount = Math.floor(gap / expectedIntervalMs) - 1;
+        result.gaps.push({
+          from: new Date(prevTimestamp).toISOString(),
+          to: timestampStr,
+          expectedCount,
+        });
+        result.warnings.push(`Line ${lineNum}: Gap detected - ${expectedCount} missing candles`);
+      }
+    }
+
+    prevTimestamp = timestamp;
+
+    // Validate OHLCV values
+    const open = parseFloat(openStr);
+    const high = parseFloat(highStr);
+    const low = parseFloat(lowStr);
+    const close = parseFloat(closeStr);
+    const volume = parseFloat(volumeStr);
+
+    if ([open, high, low, close, volume].some(isNaN)) {
+      result.errors.push(`Line ${lineNum}: Invalid numeric value`);
+      result.isValid = false;
+      continue;
+    }
+
+    // OHLC consistency checks
+    if (high < low) {
+      result.errors.push(`Line ${lineNum}: High (${high}) < Low (${low})`);
+      result.isValid = false;
+    }
+
+    if (high < open || high < close) {
+      result.warnings.push(`Line ${lineNum}: High (${high}) < Open/Close`);
+    }
+
+    if (low > open || low > close) {
+      result.warnings.push(`Line ${lineNum}: Low (${low}) > Open/Close`);
+    }
+
+    if (volume < 0) {
+      result.errors.push(`Line ${lineNum}: Negative volume (${volume})`);
+      result.isValid = false;
+    }
+  }
+
+  return result;
+}
+
+// CLI usage
+if (require.main === module) {
+  const [filePath, interval] = process.argv.slice(2);
+
+  if (!filePath) {
+    console.error('Usage: tsx validate.ts <file.csv> [interval]');
+    console.error('Intervals: 1m, 5m, 15m, 1h, 4h, 1d (default: 1m)');
+    process.exit(1);
+  }
+
+  const INTERVALS: Record<string, number> = {
+    '1m': 60000,
+    '5m': 300000,
+    '15m': 900000,
+    '1h': 3600000,
+    '4h': 14400000,
+    '1d': 86400000,
+  };
+
+  const intervalMs = INTERVALS[interval || '1m'] || 60000;
+  const result = validateCSV(filePath, intervalMs);
+
+  console.log(`\nValidation Results for: ${filePath}`);
+  console.log(`${'='.repeat(50)}`);
+  console.log(`Total rows: ${result.totalRows}`);
+  console.log(`Valid: ${result.isValid ? '✓ Yes' : '✗ No'}`);
+  console.log(`Errors: ${result.errors.length}`);
+  console.log(`Warnings: ${result.warnings.length}`);
+  console.log(`Gaps detected: ${result.gaps.length}`);
+
+  if (result.errors.length > 0) {
+    console.log(`\nErrors (first 10):`);
+    result.errors.slice(0, 10).forEach(e => console.log(`  - ${e}`));
+  }
+
+  if (result.warnings.length > 0) {
+    console.log(`\nWarnings (first 10):`);
+    result.warnings.slice(0, 10).forEach(w => console.log(`  - ${w}`));
+  }
+
+  if (result.gaps.length > 0) {
+    console.log(`\nGaps (first 5):`);
+    result.gaps.slice(0, 5).forEach(g =>
+      console.log(`  - ${g.from} -> ${g.to} (${g.expectedCount} missing)`)
+    );
+  }
+
+  process.exit(result.isValid ? 0 : 1);
+}
+```
+
+### CLI Commands for Data Transformation
+
+```typescript
+program
+  .command('resample <input> <output> <interval>')
+  .description('Resample CSV to different timeframe')
+  .action((input, output, interval) => {
+    resampleCSVFile(input, output, interval);
+  });
+
+program
+  .command('convert-format <input> <output>')
+  .description('Convert between CSV formats')
+  .option('--from <format>', 'Input format', 'binance')
+  .option('--to <format>', 'Output format', 'standard')
+  .option('-s, --symbol <symbol>', 'Symbol (for lona format)')
+  .action((input, output, options) => {
+    convertFormat({
+      inputPath: input,
+      outputPath: output,
+      inputFormat: options.from,
+      outputFormat: options.to,
+      symbol: options.symbol,
+    });
+  });
+
+program
+  .command('validate <file>')
+  .description('Validate CSV data integrity')
+  .option('-i, --interval <interval>', 'Expected interval', '1m')
+  .action((file, options) => {
+    const result = validateCSV(file, INTERVALS[options.interval]);
+    // Print results...
+  });
+```
+
+### Usage Examples
+
+```bash
+# Resample 1-minute data to 1-hour
+pnpm tsx resample.ts btcusdt-1m.csv btcusdt-1h.csv 1h
+
+# Convert Binance format to standard
+pnpm tsx format-adapter.ts binance.csv standard.csv binance standard
+
+# Convert to Lona format with symbol
+pnpm tsx format-adapter.ts standard.csv lona.csv standard lona btcusdt
+
+# Validate data integrity
+pnpm tsx validate.ts btcusdt-1m.csv 1m
+
+# Full pipeline: download -> convert -> merge -> resample
+pnpm cli bulk-download btcusdt -i 1m -s 2025-01-01 -e 2025-06-30
+pnpm cli batch-convert -d ./data/binance/btcusdt/1m -s btcusdt
+pnpm cli merge ./data/btcusdt-1m-merged.csv -d ./data/binance/btcusdt/1m
+pnpm cli resample ./data/btcusdt-1m-merged.csv ./data/btcusdt-1h.csv 1h
+```
+
+---
+
+## 10. Database Schema
+
+### Supabase/PostgreSQL Schema
+
+```sql
+-- Market data table for storing OHLCV candles
+CREATE TABLE market_data (
+  id BIGSERIAL PRIMARY KEY,
+  asset VARCHAR(20) NOT NULL,              -- e.g., 'btcusdt'
+  timestamp TIMESTAMPTZ NOT NULL,          -- Candle open time
+  open DECIMAL(20, 8) NOT NULL,
+  high DECIMAL(20, 8) NOT NULL,
+  low DECIMAL(20, 8) NOT NULL,
+  close DECIMAL(20, 8) NOT NULL,
+  volume DECIMAL(30, 8) NOT NULL,
+  source VARCHAR(20) DEFAULT 'binance',    -- Data source
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+
+  -- Unique constraint to prevent duplicates
+  CONSTRAINT unique_asset_timestamp UNIQUE (asset, timestamp)
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_market_data_asset_timestamp
+  ON market_data (asset, timestamp DESC);
+
+CREATE INDEX idx_market_data_source
+  ON market_data (source);
+
+-- Enable Row Level Security (optional)
+ALTER TABLE market_data ENABLE ROW LEVEL SECURITY;
+
+-- Allow public read access (adjust as needed)
+CREATE POLICY "Allow public read" ON market_data
+  FOR SELECT USING (true);
+```
+
+### Supabase Client
+
+```typescript
+import { createClient } from '@supabase/supabase-js';
+
+// Client-side (respects RLS)
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+// Server-side (bypasses RLS)
+export const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+// Store candles in database
+export async function storeCandles(symbol: string, candles: Candle[]): Promise<void> {
+  const insertData = candles.map(candle => ({
+    asset: symbol.toLowerCase(),
+    timestamp: candle.timestamp,
+    open: candle.open,
+    high: candle.high,
+    low: candle.low,
+    close: candle.close,
+    volume: candle.volume,
+    source: 'binance',
+  }));
+
+  // Batch insert in chunks of 500
+  const batchSize = 500;
+  for (let i = 0; i < insertData.length; i += batchSize) {
+    const batch = insertData.slice(i, i + batchSize);
+
+    const { error } = await supabaseAdmin
+      .from('market_data')
+      .upsert(batch, { onConflict: 'asset,timestamp' });
+
+    if (error) {
+      console.error(`Batch ${i / batchSize + 1} failed:`, error.message);
+    }
+  }
+}
+
+// Query candles from database
+export async function queryCandles(
+  symbol: string,
+  start: string,
+  end: string,
+  limit = 1000
+): Promise<Candle[]> {
+  const { data, error } = await supabaseAdmin
+    .from('market_data')
+    .select('timestamp, open, high, low, close, volume')
+    .eq('asset', symbol.toLowerCase())
+    .gte('timestamp', start)
+    .lte('timestamp', end)
+    .order('timestamp', { ascending: true })
+    .limit(limit);
+
+  if (error) throw error;
+  return data || [];
+}
+```
+
+---
+
+## Environment Variables
+
+```bash
+# .env.example
+
+# Upstash Redis (for caching)
+UPSTASH_REDIS_REST_URL=https://xxx.upstash.io
+UPSTASH_REDIS_REST_TOKEN=xxx
+
+# Supabase (for database storage)
+NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=xxx
+SUPABASE_SERVICE_ROLE_KEY=xxx
+
+# Binance API (optional - only needed for authenticated endpoints)
+# Not required for public market data
+BINANCE_API_KEY=xxx
+BINANCE_API_SECRET=xxx
+```
+
+---
+
+## Quick Start
+
+1. **Install dependencies:**
+   ```bash
+   pnpm add ws @upstash/redis @supabase/supabase-js commander dotenv
+   pnpm add -D typescript tsx @types/node @types/ws
+   ```
+
+2. **Copy the files you need:**
+   - `binance-websocket.ts` - Real-time streaming
+   - `binance-rest.ts` - REST API fetching
+   - `binance-bulk-download.ts` - Bulk data portal downloads
+   - `redis-cache.ts` - Caching layer
+   - `cli/index.ts` - CLI commands
+
+3. **Set up environment variables**
+
+4. **Run:**
+   ```bash
+   # Real-time streaming
+   pnpm tsx binance-websocket.ts
+
+   # Download historical data
+   pnpm cli bulk-download btcusdt -i 5m -s 2025-01-01 -e 2025-12-01
+   ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,0 @@
-import { defineConfig, globalIgnores } from 'eslint/config';
-import nextVitals from 'eslint-config-next/core-web-vitals';
-
-const eslintConfig = defineConfig([
-  ...nextVitals,
-  globalIgnores(['.next/**', 'out/**', 'build/**', 'node_modules/**']),
-]);
-
-export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
+    "lint": "biome check .",
+    "lint:fix": "biome check --fix .",
+    "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
     "cli": "tsx src/cli/index.ts"
   },
@@ -45,7 +47,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.3.3",
+    "@biomejs/biome": "^1.9.4",
     "@radix-ui/react-icons": "^1.3.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^25.2.3",
@@ -53,8 +55,6 @@
     "@types/react-dom": "^19.2.3",
     "@types/ws": "^8.18.1",
     "autoprefixer": "^10.4.24",
-    "eslint": "^10.0.0",
-    "eslint-config-next": "^16.1.6",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 3.0.50(zod@4.3.6)
       '@clerk/nextjs':
         specifier: ^6.37.3
-        version: 6.37.3(next@16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 6.37.3(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -76,7 +76,7 @@ importers:
         version: 0.563.0(react@19.2.4)
       next:
         specifier: ^16.1.6
-        version: 16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       protobufjs:
         specifier: ^8.0.0
         version: 8.0.0
@@ -102,9 +102,9 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.13)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
-      '@eslint/eslintrc':
-        specifier: ^3.3.3
-        version: 3.3.3
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
       '@radix-ui/react-icons':
         specifier: ^1.3.2
         version: 1.3.2(react@19.2.4)
@@ -126,12 +126,6 @@ importers:
       autoprefixer:
         specifier: ^10.4.24
         version: 10.4.24(postcss@8.5.6)
-      eslint:
-        specifier: ^10.0.0
-        version: 10.0.0(jiti@2.6.1)
-      eslint-config-next:
-        specifier: ^16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -194,72 +188,62 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.28.5':
-    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.28.5':
-    resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
-    engines: {node: '>=6.9.0'}
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
 
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
-    engines: {node: '>=6.9.0'}
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
 
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
-    engines: {node: '>=6.9.0'}
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@clerk/backend@2.30.1':
     resolution: {integrity: sha512-GoxnJzVH0ycNPAGCDMfo3lPBFbo5nehpLSVFjgGEnzIRGGahBtAB8PQT7KM2zo58pD8apjb/+suhcB/WCiEasQ==}
@@ -296,14 +280,8 @@ packages:
     resolution: {integrity: sha512-jl7DywmeaZx1IntgEXcjDZq2uyk+X/1yAZOjxOboeGTS0rNTiQNhv7xK8tFVjexsUAFrYlwC1AxhFuJiMDQjow==}
     engines: {node: '>=18.17.0'}
 
-  '@emnapi/core@1.7.1':
-    resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
-
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
-
-  '@emnapi/wasi-threads@1.1.0':
-    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@esbuild/aix-ppc64@0.27.1':
     resolution: {integrity: sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==}
@@ -461,40 +439,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.12.2':
-    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/config-array@0.23.1':
-    resolution: {integrity: sha512-uVSdg/V4dfQmTjJzR0szNczjOH/J+FyUMMjYtr07xFRXR7EDf9i1qdxrD0VusZH9knj1/ecxzCQQxyic5NzAiA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/config-helpers@0.5.2':
-    resolution: {integrity: sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/core@1.1.0':
-    resolution: {integrity: sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/eslintrc@3.3.3':
-    resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/object-schema@3.0.1':
-    resolution: {integrity: sha512-P9cq2dpr+LU8j3qbLygLcSZrl2/ds/pUpfnHNNuk5HW7mnngHs+6WSq5C9mO3rqRX8A1poxqLTC9cu0KOyJlBg==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/plugin-kit@0.6.0':
-    resolution: {integrity: sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
@@ -509,22 +453,6 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
-
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanwhocodes/module-importer@1.0.1':
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
-
-  '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -679,14 +607,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.1':
-    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
-    engines: {node: 20 || >=22}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -713,14 +633,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@napi-rs/wasm-runtime@0.2.12':
-    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
-
   '@next/env@16.1.6':
     resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
-
-  '@next/eslint-plugin-next@16.1.6':
-    resolution: {integrity: sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==}
 
   '@next/swc-darwin-arm64@16.1.6':
     resolution: {integrity: sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==}
@@ -773,22 +687,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
-
-  '@nolyfill/is-core-module@1.0.39':
-    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
-    engines: {node: '>=12.4.0'}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -1155,9 +1053,6 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@rtsao/scc@1.1.0':
-    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
-
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -1291,21 +1186,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
-
-  '@types/esrecurse@4.3.1':
-    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/json5@0.0.29':
-    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
@@ -1329,168 +1209,6 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript-eslint/eslint-plugin@8.48.1':
-    resolution: {integrity: sha512-X63hI1bxl5ohelzr0LY5coufyl0LJNthld+abwxpCoo6Gq+hSqhKwci7MUWkXo67mzgUK6YFByhmaHmUcuBJmA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.48.1
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/parser@8.48.1':
-    resolution: {integrity: sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.48.1':
-    resolution: {integrity: sha512-HQWSicah4s9z2/HifRPQ6b6R7G+SBx64JlFQpgSSHWPKdvCZX57XCbszg/bapbRsOEv42q5tayTYcEFpACcX1w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/scope-manager@8.48.1':
-    resolution: {integrity: sha512-rj4vWQsytQbLxC5Bf4XwZ0/CKd362DkWMUkviT7DCS057SK64D5lH74sSGzhI6PDD2HCEq02xAP9cX68dYyg1w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.48.1':
-    resolution: {integrity: sha512-k0Jhs4CpEffIBm6wPaCXBAD7jxBtrHjrSgtfCjUvPp9AZ78lXKdTR8fxyZO5y4vWNlOvYXRtngSZNSn+H53Jkw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.48.1':
-    resolution: {integrity: sha512-1jEop81a3LrJQLTf/1VfPQdhIY4PlGDBc/i67EVWObrtvcziysbLN3oReexHOM6N3jyXgCrkBsZpqwH0hiDOQg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/types@8.48.1':
-    resolution: {integrity: sha512-+fZ3LZNeiELGmimrujsDCT4CRIbq5oXdHe7chLiW8qzqyPMnn1puNstCrMNVAqwcl2FdIxkuJ4tOs/RFDBVc/Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.48.1':
-    resolution: {integrity: sha512-/9wQ4PqaefTK6POVTjJaYS0bynCgzh6ClJHGSBj06XEHjkfylzB+A3qvyaXnErEZSaxhIo4YdyBgq6j4RysxDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/utils@8.48.1':
-    resolution: {integrity: sha512-fAnhLrDjiVfey5wwFRwrweyRlCmdz5ZxXz2G/4cLn0YDLjTapmN4gcCsTBR1N2rWnZSDeWpYtgLDsJt+FpmcwA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/visitor-keys@8.48.1':
-    resolution: {integrity: sha512-BmxxndzEWhE4TIEEMBs8lP3MBWN3jFPs/p6gPm/wkv02o41hI6cq9AuSmGAaTTHPtA1FTi2jBre4A9rm5ZmX+Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
-    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
-    cpu: [arm]
-    os: [android]
-
-  '@unrs/resolver-binding-android-arm64@1.11.1':
-    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
-    cpu: [arm64]
-    os: [android]
-
-  '@unrs/resolver-binding-darwin-arm64@1.11.1':
-    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@unrs/resolver-binding-darwin-x64@1.11.1':
-    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@unrs/resolver-binding-freebsd-x64@1.11.1':
-    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
-    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
-    cpu: [arm]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
-    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
-    cpu: [arm]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
-    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
-    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
-    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
-    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
-    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
-    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
-    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
-    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
-    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
-    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
-    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
-    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
-    cpu: [x64]
-    os: [win32]
-
   '@upstash/redis@1.36.2':
     resolution: {integrity: sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A==}
 
@@ -1498,78 +1216,19 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
-  acorn-jsx@5.3.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   ai@6.0.78:
     resolution: {integrity: sha512-eriIX/NLWfWNDeE/OJy8wmIp9fyaH7gnxTOCPT5bp0MNkvORstp1TwRUql9au8XjXzH7o2WApqbwgxJDDV0Rbw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
-
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
-
-  aria-query@5.3.2:
-    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
-    engines: {node: '>= 0.4'}
-
-  array-buffer-byte-length@1.0.2:
-    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
-    engines: {node: '>= 0.4'}
-
-  array-includes@3.1.9:
-    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.findlast@1.2.5:
-    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.findlastindex@1.2.6:
-    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.flat@1.3.3:
-    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.flatmap@1.3.3:
-    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.tosorted@1.1.4:
-    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
-    engines: {node: '>= 0.4'}
-
-  arraybuffer.prototype.slice@1.0.4:
-    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
-    engines: {node: '>= 0.4'}
-
-  ast-types-flow@0.0.8:
-    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
-
-  async-function@1.0.0:
-    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
-    engines: {node: '>= 0.4'}
 
   autoprefixer@10.4.24:
     resolution: {integrity: sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==}
@@ -1578,55 +1237,14 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
-
-  axe-core@4.11.0:
-    resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
-    engines: {node: '>=4'}
-
-  axobject-query@4.1.0:
-    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
-    engines: {node: '>= 0.4'}
-
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   baseline-browser-mapping@2.9.4:
     resolution: {integrity: sha512-ZCQ9GEWl73BVm8bu5Fts8nt7MHdbt5vY9bP6WGnUh+r3l8M7CgfyTlwsgCbMC66BNxPr6Xoce3j66Ms5YUQTNA==}
     hasBin: true
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
-
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001760:
     resolution: {integrity: sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==}
@@ -1663,67 +1281,14 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   console-table-printer@2.15.0:
     resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
-
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  damerau-levenshtein@1.0.8:
-    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
-
-  data-view-buffer@1.0.2:
-    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
-    engines: {node: '>= 0.4'}
-
-  data-view-byte-length@1.0.2:
-    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
-    engines: {node: '>= 0.4'}
-
-  data-view-byte-offset@1.0.1:
-    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
-    engines: {node: '>= 0.4'}
-
-  debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
-
-  define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1736,10 +1301,6 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
-  doctrine@2.1.0:
-    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
-    engines: {node: '>=0.10.0'}
-
   dompurify@3.2.7:
     resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
@@ -1747,51 +1308,12 @@ packages:
     resolution: {integrity: sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==}
     engines: {node: '>=12'}
 
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
-
   electron-to-chromium@1.5.266:
     resolution: {integrity: sha512-kgWEglXvkEfMH7rxP5OSZZwnaDWT7J9EoZCujhnpLbfi0bbNtRkgdX2E3gt0Uer11c61qCYktB3hwkAS325sJg==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
-
-  es-abstract@1.24.0:
-    resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
-    engines: {node: '>= 0.4'}
-
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-iterator-helpers@1.2.1:
-    resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
-    engines: {node: '>= 0.4'}
-
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
-
-  es-shim-unscopables@1.1.0:
-    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
-    engines: {node: '>= 0.4'}
-
-  es-to-primitive@1.3.0:
-    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
-    engines: {node: '>= 0.4'}
 
   esbuild@0.27.1:
     resolution: {integrity: sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==}
@@ -1801,134 +1323,6 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
-
-  eslint-config-next@16.1.6:
-    resolution: {integrity: sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==}
-    peerDependencies:
-      eslint: '>=9.0.0'
-      typescript: '>=3.3.1'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  eslint-import-resolver-node@0.3.9:
-    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
-
-  eslint-import-resolver-typescript@3.10.1:
-    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      eslint-plugin-import: '*'
-      eslint-plugin-import-x: '*'
-    peerDependenciesMeta:
-      eslint-plugin-import:
-        optional: true
-      eslint-plugin-import-x:
-        optional: true
-
-  eslint-module-utils@2.12.1:
-    resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-
-  eslint-plugin-import@2.32.0:
-    resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-
-  eslint-plugin-jsx-a11y@6.10.2:
-    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
-
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-
-  eslint-plugin-react@7.37.5:
-    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
-
-  eslint-scope@9.1.0:
-    resolution: {integrity: sha512-CkWE42hOJsNj9FJRaoMX9waUFYhqY4jmyLFdAdzZr6VaCg3ynLYx4WnOdkaIifGfH4gsUcBTn4OZbHXkpLD0FQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  eslint-visitor-keys@5.0.0:
-    resolution: {integrity: sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  eslint@10.0.0:
-    resolution: {integrity: sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
-  espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  espree@11.1.0:
-    resolution: {integrity: sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  esquery@1.7.0:
-    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
-    engines: {node: '>=0.10'}
-
-  esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -1940,56 +1334,8 @@ packages:
   fancy-canvas@2.1.0:
     resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
 
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-glob@3.3.1:
-    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
-    engines: {node: '>=8.6.0'}
-
-  fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-
-  fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
-
-  fastq@1.19.1:
-    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
-
-  fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-
-  file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
-
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
-
-  find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
-
-  flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
-
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
-
-  for-each@0.3.5:
-    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
-    engines: {node: '>= 0.4'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -1999,245 +1345,26 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  function.prototype.name@1.1.8:
-    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
-    engines: {node: '>= 0.4'}
-
-  functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-
-  generator-function@2.0.1:
-    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
-    engines: {node: '>= 0.4'}
-
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
-
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
-
-  get-symbol-description@1.1.0:
-    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
-    engines: {node: '>= 0.4'}
-
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
-
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-
-  glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
-
-  globals@16.4.0:
-    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
-    engines: {node: '>=18'}
-
-  globalthis@1.0.4:
-    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
-    engines: {node: '>= 0.4'}
-
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-
-  has-bigints@1.1.0:
-    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
-    engines: {node: '>= 0.4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-
-  has-proto@1.2.0:
-    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
-    engines: {node: '>= 0.4'}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-
-  hermes-estree@0.25.1:
-    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
-
-  hermes-parser@0.25.1:
-    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
-
-  ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
-
-  import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
-
-  imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-
-  internal-slot@1.1.0:
-    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
-    engines: {node: '>= 0.4'}
-
-  is-array-buffer@3.0.5:
-    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
-    engines: {node: '>= 0.4'}
-
-  is-async-function@2.1.1:
-    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
-    engines: {node: '>= 0.4'}
-
-  is-bigint@1.1.0:
-    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
-    engines: {node: '>= 0.4'}
-
-  is-boolean-object@1.2.2:
-    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
-    engines: {node: '>= 0.4'}
-
-  is-bun-module@2.0.0:
-    resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
-
-  is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
-
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
-    engines: {node: '>= 0.4'}
-
-  is-data-view@1.0.2:
-    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
-    engines: {node: '>= 0.4'}
-
-  is-date-object@1.1.0:
-    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
-    engines: {node: '>= 0.4'}
-
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
-  is-finalizationregistry@1.1.1:
-    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
-    engines: {node: '>= 0.4'}
-
-  is-generator-function@1.1.2:
-    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
-    engines: {node: '>= 0.4'}
-
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-
-  is-map@2.0.3:
-    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
-
-  is-negative-zero@2.0.3:
-    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
-    engines: {node: '>= 0.4'}
-
-  is-number-object@1.1.1:
-    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
-    engines: {node: '>= 0.4'}
-
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-
-  is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
-
-  is-set@2.0.3:
-    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
-    engines: {node: '>= 0.4'}
-
-  is-shared-array-buffer@1.0.4:
-    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
-    engines: {node: '>= 0.4'}
-
-  is-string@1.1.1:
-    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
-    engines: {node: '>= 0.4'}
-
-  is-symbol@1.1.1:
-    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
-    engines: {node: '>= 0.4'}
-
-  is-typed-array@1.1.15:
-    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
-    engines: {node: '>= 0.4'}
-
-  is-weakmap@2.0.2:
-    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
-    engines: {node: '>= 0.4'}
-
-  is-weakref@1.1.1:
-    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
-    engines: {node: '>= 0.4'}
-
-  is-weakset@2.0.4:
-    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
-    engines: {node: '>= 0.4'}
-
-  isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  iterator.prototype@1.1.5:
-    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
-    engines: {node: '>= 0.4'}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2247,45 +1374,8 @@ packages:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
 
-  js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
-  jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
-    hasBin: true
-
-  json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-
-  json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-
-  json5@1.0.2:
-    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
-    hasBin: true
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
-
-  jsx-ast-utils@3.3.5:
-    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
-    engines: {node: '>=4.0'}
-
-  keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   langsmith@0.5.2:
     resolution: {integrity: sha512-CfkcQsiajtTWknAcyItvJsKEQdY2VgDpm6U8pRI9wnM07mevnOv5EF+RcqWGwx37SEUxtyi2RXMwnKW8b06JtA==}
@@ -2303,17 +1393,6 @@ packages:
         optional: true
       openai:
         optional: true
-
-  language-subtag-registry@0.3.23:
-    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
-
-  language-tags@1.0.9:
-    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
-    engines: {node: '>=0.10'}
-
-  levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -2392,19 +1471,8 @@ packages:
   lightweight-charts@5.1.0:
     resolution: {integrity: sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==}
 
-  locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
-
-  loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
-
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lucide-react@0.563.0:
     resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
@@ -2419,50 +1487,13 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-
-  micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
-
-  minimatch@10.1.2:
-    resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
-    engines: {node: 20 || >=22}
-
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  napi-postinstall@0.3.4:
-    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-    hasBin: true
-
-  natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   next@16.1.6:
     resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
@@ -2488,57 +1519,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
-  object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
-
-  object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
-
-  object.assign@4.1.7:
-    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
-    engines: {node: '>= 0.4'}
-
-  object.entries@1.1.9:
-    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
-    engines: {node: '>= 0.4'}
-
-  object.fromentries@2.0.8:
-    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
-    engines: {node: '>= 0.4'}
-
-  object.groupby@1.0.3:
-    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
-    engines: {node: '>= 0.4'}
-
-  object.values@1.2.1:
-    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
-    engines: {node: '>= 0.4'}
-
-  optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
-
-  own-keys@1.0.1:
-    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
-    engines: {node: '>= 0.4'}
-
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
-
-  p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
-
-  p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
 
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
@@ -2548,35 +1531,8 @@ packages:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-
-  path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
-  possible-typed-array-names@1.1.0:
-    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
-    engines: {node: '>= 0.4'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -2589,31 +1545,14 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
-
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
   protobufjs@8.0.0:
     resolution: {integrity: sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==}
     engines: {node: '>=12.0.0'}
-
-  punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
-
-  queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
-
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -2649,55 +1588,11 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
-  reflect.getprototypeof@1.0.10:
-    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
-    engines: {node: '>= 0.4'}
-
-  regexp.prototype.flags@1.5.4:
-    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
-    engines: {node: '>= 0.4'}
-
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
-  resolve@2.0.0-next.5:
-    resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
-    hasBin: true
-
-  reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  safe-array-concat@1.1.3:
-    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
-    engines: {node: '>=0.4'}
-
-  safe-push-apply@1.0.0:
-    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
-    engines: {node: '>= 0.4'}
-
-  safe-regex-test@1.1.0:
-    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
-    engines: {node: '>= 0.4'}
-
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
@@ -2707,45 +1602,9 @@ packages:
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
-  set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
-
-  set-function-name@2.0.2:
-    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
-    engines: {node: '>= 0.4'}
-
-  set-proto@1.0.0:
-    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
-    engines: {node: '>= 0.4'}
-
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
 
   simple-wcswidth@1.1.2:
     resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
@@ -2753,9 +1612,6 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-
-  stable-hash@0.0.5:
-    resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
@@ -2765,41 +1621,6 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  stop-iteration-iterator@1.1.0:
-    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.includes@2.0.1:
-    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.matchall@4.0.12:
-    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.repeat@1.0.0:
-    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
-
-  string.prototype.trim@1.2.10:
-    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trimend@1.0.9:
-    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trimstart@1.0.8:
-    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
-    engines: {node: '>= 0.4'}
-
-  strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
-
-  strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -2818,10 +1639,6 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
-
   swr@2.3.4:
     resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
     peerDependencies:
@@ -2837,23 +1654,6 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
-  tsconfig-paths@3.15.0:
-    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2862,41 +1662,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
-
-  typed-array-buffer@1.0.3:
-    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-byte-length@1.0.3:
-    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-byte-offset@1.0.4:
-    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-length@1.0.7:
-    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
-    engines: {node: '>= 0.4'}
-
-  typescript-eslint@8.48.1:
-    resolution: {integrity: sha512-FbOKN1fqNoXp1hIl5KYpObVrp0mCn+CLgn479nmu2IsRMrx2vyv74MmsBLVlhg8qVwNFGbXSp8fh1zp8pEoC2A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  unbox-primitive@1.1.0:
-    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
-    engines: {node: '>= 0.4'}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -2904,17 +1673,11 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  unrs-resolver@1.11.1:
-    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
-
   update-browserslist-db@1.2.2:
     resolution: {integrity: sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -2945,31 +1708,6 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
-  which-boxed-primitive@1.1.1:
-    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
-    engines: {node: '>= 0.4'}
-
-  which-builtin-type@1.2.1:
-    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
-    engines: {node: '>= 0.4'}
-
-  which-collection@1.0.2:
-    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
-    engines: {node: '>= 0.4'}
-
-  which-typed-array@1.1.19:
-    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
-    engines: {node: '>= 0.4'}
-
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
-  word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
-
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -2981,19 +1719,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
-
-  zod-validation-error@4.0.2:
-    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -3069,105 +1794,40 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@babel/code-frame@7.27.1':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
 
-  '@babel/compat-data@7.28.5': {}
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
 
-  '@babel/core@7.28.5':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
 
-  '@babel/generator@7.28.5':
-    dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
 
-  '@babel/helper-compilation-targets@7.27.2':
-    dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
-      lru-cache: 5.1.1
-      semver: 6.3.1
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
 
-  '@babel/helper-globals@7.28.0': {}
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
 
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
 
-  '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
-
-  '@babel/helper-validator-option@7.27.1': {}
-
-  '@babel/helpers@7.28.4':
-    dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.5
-
-  '@babel/template@7.27.2':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-
-  '@babel/traverse@7.28.5':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
 
   '@clerk/backend@2.30.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3186,13 +1846,13 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       tslib: 2.8.1
 
-  '@clerk/nextjs@6.37.3(next@16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@clerk/nextjs@6.37.3(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@clerk/backend': 2.30.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@clerk/clerk-react': 5.60.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@clerk/shared': 3.44.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@clerk/types': 4.101.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      next: 16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       server-only: 0.0.1
@@ -3217,18 +1877,7 @@ snapshots:
       - react
       - react-dom
 
-  '@emnapi/core@1.7.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.1.0
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.7.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3311,50 +1960,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@10.0.0(jiti@2.6.1))':
-    dependencies:
-      eslint: 10.0.0(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/regexpp@4.12.2': {}
-
-  '@eslint/config-array@0.23.1':
-    dependencies:
-      '@eslint/object-schema': 3.0.1
-      debug: 4.4.3
-      minimatch: 10.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/config-helpers@0.5.2':
-    dependencies:
-      '@eslint/core': 1.1.0
-
-  '@eslint/core@1.1.0':
-    dependencies:
-      '@types/json-schema': 7.0.15
-
-  '@eslint/eslintrc@3.3.3':
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.4.3
-      espree: 10.4.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/object-schema@3.0.1': {}
-
-  '@eslint/plugin-kit@0.6.0':
-    dependencies:
-      '@eslint/core': 1.1.0
-      levn: 0.4.1
-
   '@floating-ui/core@1.7.3':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -3371,17 +1976,6 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.10': {}
-
-  '@humanfs/core@0.19.1': {}
-
-  '@humanfs/node@0.16.7':
-    dependencies:
-      '@humanfs/core': 0.19.1
-      '@humanwhocodes/retry': 0.4.3
-
-  '@humanwhocodes/module-importer@1.0.1': {}
-
-  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/colour@1.0.0':
     optional: true
@@ -3480,12 +2074,6 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.1':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3516,18 +2104,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@napi-rs/wasm-runtime@0.2.12':
-    dependencies:
-      '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.7.1
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@next/env@16.1.6': {}
-
-  '@next/eslint-plugin-next@16.1.6':
-    dependencies:
-      fast-glob: 3.3.1
 
   '@next/swc-darwin-arm64@16.1.6':
     optional: true
@@ -3552,20 +2129,6 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
-
-  '@nodelib/fs.scandir@2.1.5':
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.19.1
-
-  '@nolyfill/is-core-module@1.0.39': {}
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -3882,8 +2445,6 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rtsao/scc@1.1.0': {}
-
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -4006,19 +2567,6 @@ snapshots:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@types/esrecurse@4.3.1': {}
-
-  '@types/estree@1.0.8': {}
-
-  '@types/json-schema@7.0.15': {}
-
-  '@types/json5@0.0.29': {}
-
   '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
@@ -4042,168 +2590,11 @@ snapshots:
     dependencies:
       '@types/node': 25.2.3
 
-  '@typescript-eslint/eslint-plugin@8.48.1(@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.48.1
-      '@typescript-eslint/type-utils': 8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.48.1
-      eslint: 10.0.0(jiti@2.6.1)
-      graphemer: 1.4.0
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.48.1
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.48.1
-      debug: 4.4.3
-      eslint: 10.0.0(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.48.1(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.48.1
-      debug: 4.4.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/scope-manager@8.48.1':
-    dependencies:
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/visitor-keys': 8.48.1
-
-  '@typescript-eslint/tsconfig-utils@8.48.1(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
-  '@typescript-eslint/type-utils@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 10.0.0(jiti@2.6.1)
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/types@8.48.1': {}
-
-  '@typescript-eslint/typescript-estree@8.48.1(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/visitor-keys': 8.48.1
-      debug: 4.4.3
-      minimatch: 9.0.5
-      semver: 7.7.3
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.0.0(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.48.1
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
-      eslint: 10.0.0(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/visitor-keys@8.48.1':
-    dependencies:
-      '@typescript-eslint/types': 8.48.1
-      eslint-visitor-keys: 4.2.1
-
-  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-android-arm64@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-darwin-arm64@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-darwin-x64@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-freebsd-x64@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
-    dependencies:
-      '@napi-rs/wasm-runtime': 0.2.12
-    optional: true
-
-  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
-    optional: true
-
-  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
-    optional: true
-
   '@upstash/redis@1.36.2':
     dependencies:
       uncrypto: 0.1.3
 
   '@vercel/oidc@3.1.0': {}
-
-  acorn-jsx@5.3.2(acorn@8.15.0):
-    dependencies:
-      acorn: 8.15.0
-
-  acorn@8.15.0: {}
 
   ai@6.0.78(zod@4.3.6):
     dependencies:
@@ -4213,95 +2604,13 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
-  ajv@6.12.6:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
-  argparse@2.0.1: {}
-
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
-
-  aria-query@5.3.2: {}
-
-  array-buffer-byte-length@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      is-array-buffer: 3.0.5
-
-  array-includes@3.1.9:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-object-atoms: 1.1.1
-      get-intrinsic: 1.3.0
-      is-string: 1.1.1
-      math-intrinsics: 1.1.0
-
-  array.prototype.findlast@1.2.5:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      es-shim-unscopables: 1.1.0
-
-  array.prototype.findlastindex@1.2.6:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      es-shim-unscopables: 1.1.0
-
-  array.prototype.flat@1.3.3:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-shim-unscopables: 1.1.0
-
-  array.prototype.flatmap@1.3.3:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-shim-unscopables: 1.1.0
-
-  array.prototype.tosorted@1.1.4:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-errors: 1.3.0
-      es-shim-unscopables: 1.1.0
-
-  arraybuffer.prototype.slice@1.0.4:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      is-array-buffer: 3.0.5
-
-  ast-types-flow@0.0.8: {}
-
-  async-function@1.0.0: {}
 
   autoprefixer@10.4.24(postcss@8.5.6):
     dependencies:
@@ -4312,30 +2621,7 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  available-typed-arrays@1.0.7:
-    dependencies:
-      possible-typed-array-names: 1.1.0
-
-  axe-core@4.11.0: {}
-
-  axobject-query@4.1.0: {}
-
-  balanced-match@1.0.2: {}
-
   baseline-browser-mapping@2.9.4: {}
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
 
   browserslist@4.28.1:
     dependencies:
@@ -4344,25 +2630,6 @@ snapshots:
       electron-to-chromium: 1.5.266
       node-releases: 2.0.27
       update-browserslist-db: 1.2.2(browserslist@4.28.1)
-
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
-  call-bind@1.0.8:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
-
-  callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001760: {}
 
@@ -4396,65 +2663,13 @@ snapshots:
 
   commander@14.0.3: {}
 
-  concat-map@0.0.1: {}
-
   console-table-printer@2.15.0:
     dependencies:
       simple-wcswidth: 1.1.2
 
-  convert-source-map@2.0.0: {}
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
   csstype@3.1.3: {}
 
   csstype@3.2.3: {}
-
-  damerau-levenshtein@1.0.8: {}
-
-  data-view-buffer@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  data-view-byte-length@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  data-view-byte-offset@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  debug@3.2.7:
-    dependencies:
-      ms: 2.1.3
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
-  deep-is@0.1.4: {}
-
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
 
   dequal@2.0.3: {}
 
@@ -4462,131 +2677,18 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  doctrine@2.1.0:
-    dependencies:
-      esutils: 2.0.3
-
   dompurify@3.2.7:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
   dotenv@17.2.4: {}
 
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
   electron-to-chromium@1.5.266: {}
-
-  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
-
-  es-abstract@1.24.0:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      arraybuffer.prototype.slice: 1.0.4
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      data-view-buffer: 1.0.2
-      data-view-byte-length: 1.0.2
-      data-view-byte-offset: 1.0.1
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      es-set-tostringtag: 2.1.0
-      es-to-primitive: 1.3.0
-      function.prototype.name: 1.1.8
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      get-symbol-description: 1.1.0
-      globalthis: 1.0.4
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-      has-proto: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.2
-      internal-slot: 1.1.0
-      is-array-buffer: 3.0.5
-      is-callable: 1.2.7
-      is-data-view: 1.0.2
-      is-negative-zero: 2.0.3
-      is-regex: 1.2.1
-      is-set: 2.0.3
-      is-shared-array-buffer: 1.0.4
-      is-string: 1.1.1
-      is-typed-array: 1.1.15
-      is-weakref: 1.1.1
-      math-intrinsics: 1.1.0
-      object-inspect: 1.13.4
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      own-keys: 1.0.1
-      regexp.prototype.flags: 1.5.4
-      safe-array-concat: 1.1.3
-      safe-push-apply: 1.0.0
-      safe-regex-test: 1.1.0
-      set-proto: 1.0.0
-      stop-iteration-iterator: 1.1.0
-      string.prototype.trim: 1.2.10
-      string.prototype.trimend: 1.0.9
-      string.prototype.trimstart: 1.0.8
-      typed-array-buffer: 1.0.3
-      typed-array-byte-length: 1.0.3
-      typed-array-byte-offset: 1.0.4
-      typed-array-length: 1.0.7
-      unbox-primitive: 1.1.0
-      which-typed-array: 1.1.19
-
-  es-define-property@1.0.1: {}
-
-  es-errors@1.3.0: {}
-
-  es-iterator-helpers@1.2.1:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-errors: 1.3.0
-      es-set-tostringtag: 2.1.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      globalthis: 1.0.4
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-      has-proto: 1.2.0
-      has-symbols: 1.1.0
-      internal-slot: 1.1.0
-      iterator.prototype: 1.1.5
-      safe-array-concat: 1.1.3
-
-  es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
-
-  es-shim-unscopables@1.1.0:
-    dependencies:
-      hasown: 2.0.2
-
-  es-to-primitive@1.3.0:
-    dependencies:
-      is-callable: 1.2.7
-      is-date-object: 1.1.0
-      is-symbol: 1.1.1
 
   esbuild@0.27.1:
     optionalDependencies:
@@ -4619,556 +2721,38 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-string-regexp@4.0.0: {}
-
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.1.6
-      eslint: 10.0.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.0.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.0.0(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@10.0.0(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@10.0.0(jiti@2.6.1))
-      globals: 16.4.0
-      typescript-eslint: 8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
-  eslint-import-resolver-node@0.3.9:
-    dependencies:
-      debug: 3.2.7
-      is-core-module: 2.16.1
-      resolve: 1.22.11
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.0.0(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 10.0.0(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 10.0.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.0.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 10.0.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.0(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-jsx-a11y@6.10.2(eslint@10.0.0(jiti@2.6.1)):
-    dependencies:
-      aria-query: 5.3.2
-      array-includes: 3.1.9
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.11.0
-      axobject-query: 4.1.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 10.0.0(jiti@2.6.1)
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
-
-  eslint-plugin-react-hooks@7.0.1(eslint@10.0.0(jiti@2.6.1)):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
-      eslint: 10.0.0(jiti@2.6.1)
-      hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-react@7.37.5(eslint@10.0.0(jiti@2.6.1)):
-    dependencies:
-      array-includes: 3.1.9
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.2.1
-      eslint: 10.0.0(jiti@2.6.1)
-      estraverse: 5.3.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.9
-      object.fromentries: 2.0.8
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-      string.prototype.repeat: 1.0.0
-
-  eslint-scope@9.1.0:
-    dependencies:
-      '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
-  eslint-visitor-keys@3.4.3: {}
-
-  eslint-visitor-keys@4.2.1: {}
-
-  eslint-visitor-keys@5.0.0: {}
-
-  eslint@10.0.0(jiti@2.6.1):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.0.0(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.1
-      '@eslint/config-helpers': 0.5.2
-      '@eslint/core': 1.1.0
-      '@eslint/plugin-kit': 0.6.0
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.12.6
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.0
-      eslint-visitor-keys: 5.0.0
-      espree: 11.1.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.6.1
-    transitivePeerDependencies:
-      - supports-color
-
-  espree@10.4.0:
-    dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
-      eslint-visitor-keys: 4.2.1
-
-  espree@11.1.0:
-    dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
-      eslint-visitor-keys: 5.0.0
-
-  esquery@1.7.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  esrecurse@4.3.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  estraverse@5.3.0: {}
-
-  esutils@2.0.3: {}
-
   eventemitter3@4.0.7: {}
 
   eventsource-parser@3.0.6: {}
 
   fancy-canvas@2.1.0: {}
 
-  fast-deep-equal@3.1.3: {}
-
-  fast-glob@3.3.1:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
-  fast-json-stable-stringify@2.1.0: {}
-
-  fast-levenshtein@2.0.6: {}
-
   fast-sha256@1.3.0: {}
-
-  fastq@1.19.1:
-    dependencies:
-      reusify: 1.1.0
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
-  file-entry-cache@8.0.0:
-    dependencies:
-      flat-cache: 4.0.1
-
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
-
-  find-up@5.0.0:
-    dependencies:
-      locate-path: 6.0.0
-      path-exists: 4.0.0
-
-  flat-cache@4.0.1:
-    dependencies:
-      flatted: 3.3.3
-      keyv: 4.5.4
-
-  flatted@3.3.3: {}
-
-  for-each@0.3.5:
-    dependencies:
-      is-callable: 1.2.7
 
   fraction.js@5.3.4: {}
 
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2: {}
-
-  function.prototype.name@1.1.8:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      functions-have-names: 1.2.3
-      hasown: 2.0.2
-      is-callable: 1.2.7
-
-  functions-have-names@1.2.3: {}
-
-  generator-function@2.0.1: {}
-
-  gensync@1.0.0-beta.2: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.2
-      math-intrinsics: 1.1.0
-
   get-nonce@1.0.1: {}
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
-
-  get-symbol-description@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
 
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
-  glob-parent@6.0.2:
-    dependencies:
-      is-glob: 4.0.3
-
   glob-to-regexp@0.4.1: {}
-
-  globals@14.0.0: {}
-
-  globals@16.4.0: {}
-
-  globalthis@1.0.4:
-    dependencies:
-      define-properties: 1.2.1
-      gopd: 1.2.0
-
-  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
-  graphemer@1.4.0: {}
-
-  has-bigints@1.1.0: {}
-
   has-flag@4.0.0: {}
 
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
-
-  has-proto@1.2.0:
-    dependencies:
-      dunder-proto: 1.0.1
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
-  hermes-estree@0.25.1: {}
-
-  hermes-parser@0.25.1:
-    dependencies:
-      hermes-estree: 0.25.1
-
   iceberg-js@0.8.1: {}
-
-  ignore@5.3.2: {}
-
-  ignore@7.0.5: {}
-
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-
-  imurmurhash@0.1.4: {}
-
-  internal-slot@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      hasown: 2.0.2
-      side-channel: 1.1.0
-
-  is-array-buffer@3.0.5:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-
-  is-async-function@2.1.1:
-    dependencies:
-      async-function: 1.0.0
-      call-bound: 1.0.4
-      get-proto: 1.0.1
-      has-tostringtag: 1.0.2
-      safe-regex-test: 1.1.0
-
-  is-bigint@1.1.0:
-    dependencies:
-      has-bigints: 1.1.0
-
-  is-boolean-object@1.2.2:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-bun-module@2.0.0:
-    dependencies:
-      semver: 7.7.3
-
-  is-callable@1.2.7: {}
-
-  is-core-module@2.16.1:
-    dependencies:
-      hasown: 2.0.2
-
-  is-data-view@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-      is-typed-array: 1.1.15
-
-  is-date-object@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-extglob@2.1.1: {}
-
-  is-finalizationregistry@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-generator-function@1.1.2:
-    dependencies:
-      call-bound: 1.0.4
-      generator-function: 2.0.1
-      get-proto: 1.0.1
-      has-tostringtag: 1.0.2
-      safe-regex-test: 1.1.0
-
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
-
-  is-map@2.0.3: {}
-
-  is-negative-zero@2.0.3: {}
-
-  is-number-object@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-number@7.0.0: {}
-
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
-
-  is-set@2.0.3: {}
-
-  is-shared-array-buffer@1.0.4:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-string@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-symbol@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-      has-symbols: 1.1.0
-      safe-regex-test: 1.1.0
-
-  is-typed-array@1.1.15:
-    dependencies:
-      which-typed-array: 1.1.19
-
-  is-weakmap@2.0.2: {}
-
-  is-weakref@1.1.1:
-    dependencies:
-      call-bound: 1.0.4
-
-  is-weakset@2.0.4:
-    dependencies:
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-
-  isarray@2.0.5: {}
-
-  isexe@2.0.0: {}
-
-  iterator.prototype@1.1.5:
-    dependencies:
-      define-data-property: 1.1.4
-      es-object-atoms: 1.1.1
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      has-symbols: 1.1.0
-      set-function-name: 2.0.2
 
   jiti@2.6.1: {}
 
   js-cookie@3.0.5: {}
 
-  js-tokens@4.0.0: {}
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
-  jsesc@3.1.0: {}
-
-  json-buffer@3.0.1: {}
-
-  json-schema-traverse@0.4.1: {}
-
   json-schema@0.4.0: {}
-
-  json-stable-stringify-without-jsonify@1.0.1: {}
-
-  json5@1.0.2:
-    dependencies:
-      minimist: 1.2.8
-
-  json5@2.2.3: {}
-
-  jsx-ast-utils@3.3.5:
-    dependencies:
-      array-includes: 3.1.9
-      array.prototype.flat: 1.3.3
-      object.assign: 4.1.7
-      object.values: 1.2.1
-
-  keyv@4.5.4:
-    dependencies:
-      json-buffer: 3.0.1
 
   langsmith@0.5.2(@opentelemetry/api@1.9.0):
     dependencies:
@@ -5180,17 +2764,6 @@ snapshots:
       uuid: 10.0.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-
-  language-subtag-registry@0.3.23: {}
-
-  language-tags@1.0.9:
-    dependencies:
-      language-subtag-registry: 0.3.23
-
-  levn@0.4.1:
-    dependencies:
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -5245,19 +2818,7 @@ snapshots:
     dependencies:
       fancy-canvas: 2.1.0
 
-  locate-path@6.0.0:
-    dependencies:
-      p-locate: 5.0.0
-
   long@5.3.2: {}
-
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
-
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
 
   lucide-react@0.563.0(react@19.2.4):
     dependencies:
@@ -5269,43 +2830,14 @@ snapshots:
 
   marked@14.0.0: {}
 
-  math-intrinsics@1.1.0: {}
-
-  merge2@1.4.1: {}
-
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.1
-
-  minimatch@10.1.2:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.1
-
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.2
-
-  minimist@1.2.8: {}
-
   monaco-editor@0.55.1:
     dependencies:
       dompurify: 3.2.7
       marked: 14.0.0
 
-  ms@2.1.3: {}
-
   nanoid@3.3.11: {}
 
-  napi-postinstall@0.3.4: {}
-
-  natural-compare@1.4.0: {}
-
-  next@16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -5314,7 +2846,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -5332,72 +2864,7 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  object-assign@4.1.1: {}
-
-  object-inspect@1.13.4: {}
-
-  object-keys@1.1.1: {}
-
-  object.assign@4.1.7:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.1
-      has-symbols: 1.1.0
-      object-keys: 1.1.1
-
-  object.entries@1.1.9:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.1
-
-  object.fromentries@2.0.8:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-object-atoms: 1.1.1
-
-  object.groupby@1.0.3:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-
-  object.values@1.2.1:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.1
-
-  optionator@0.9.4:
-    dependencies:
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.4.1
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
-      word-wrap: 1.2.5
-
-  own-keys@1.0.1:
-    dependencies:
-      get-intrinsic: 1.3.0
-      object-keys: 1.1.1
-      safe-push-apply: 1.0.0
-
   p-finally@1.0.0: {}
-
-  p-limit@3.1.0:
-    dependencies:
-      yocto-queue: 0.1.0
-
-  p-locate@5.0.0:
-    dependencies:
-      p-limit: 3.1.0
 
   p-queue@6.6.2:
     dependencies:
@@ -5408,23 +2875,7 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
-
-  path-exists@4.0.0: {}
-
-  path-key@3.1.1: {}
-
-  path-parse@1.0.7: {}
-
   picocolors@1.1.1: {}
-
-  picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
-
-  possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
 
@@ -5439,14 +2890,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  prelude-ls@1.2.1: {}
-
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
 
   protobufjs@8.0.0:
     dependencies:
@@ -5463,16 +2906,10 @@ snapshots:
       '@types/node': 25.2.3
       long: 5.3.2
 
-  punycode@2.3.1: {}
-
-  queue-microtask@1.2.3: {}
-
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
-
-  react-is@16.13.1: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.13)(react@19.2.4):
     dependencies:
@@ -5503,96 +2940,13 @@ snapshots:
 
   react@19.2.4: {}
 
-  reflect.getprototypeof@1.0.10:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      which-builtin-type: 1.2.1
-
-  regexp.prototype.flags@1.5.4:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-errors: 1.3.0
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      set-function-name: 2.0.2
-
-  resolve-from@4.0.0: {}
-
   resolve-pkg-maps@1.0.0: {}
 
-  resolve@1.22.11:
-    dependencies:
-      is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
-  resolve@2.0.0-next.5:
-    dependencies:
-      is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
-  reusify@1.1.0: {}
-
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
-
-  safe-array-concat@1.1.3:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      isarray: 2.0.5
-
-  safe-push-apply@1.0.0:
-    dependencies:
-      es-errors: 1.3.0
-      isarray: 2.0.5
-
-  safe-regex-test@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-regex: 1.2.1
-
   scheduler@0.27.0: {}
-
-  semver@6.3.1: {}
 
   semver@7.7.3: {}
 
   server-only@0.0.1: {}
-
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-
-  set-function-name@2.0.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      functions-have-names: 1.2.3
-      has-property-descriptors: 1.0.2
-
-  set-proto@1.0.0:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
 
   sharp@0.34.5:
     dependencies:
@@ -5626,45 +2980,9 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
-  side-channel-list@1.0.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.0
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
-
   simple-wcswidth@1.1.2: {}
 
   source-map-js@1.2.1: {}
-
-  stable-hash@0.0.5: {}
 
   standardwebhooks@1.0.0:
     dependencies:
@@ -5675,77 +2993,14 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  stop-iteration-iterator@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      internal-slot: 1.1.0
-
-  string.prototype.includes@2.0.1:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-
-  string.prototype.matchall@4.0.12:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      internal-slot: 1.1.0
-      regexp.prototype.flags: 1.5.4
-      set-function-name: 2.0.2
-      side-channel: 1.1.0
-
-  string.prototype.repeat@1.0.0:
-    dependencies:
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-
-  string.prototype.trim@1.2.10:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-data-property: 1.1.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-object-atoms: 1.1.1
-      has-property-descriptors: 1.0.2
-
-  string.prototype.trimend@1.0.9:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.1
-
-  string.prototype.trimstart@1.0.8:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.1
-
-  strip-bom@3.0.0: {}
-
-  strip-json-comments@3.1.1: {}
-
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.4):
+  styled-jsx@5.1.6(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
-    optionalDependencies:
-      '@babel/core': 7.28.5
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  supports-preserve-symlinks-flag@1.0.0: {}
 
   swr@2.3.4(react@19.2.4):
     dependencies:
@@ -5759,26 +3014,6 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
-
-  ts-api-utils@2.1.0(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
-
-  tsconfig-paths@3.15.0:
-    dependencies:
-      '@types/json5': 0.0.29
-      json5: 1.0.2
-      minimist: 1.2.8
-      strip-bom: 3.0.0
-
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -5788,100 +3023,17 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  type-check@0.4.0:
-    dependencies:
-      prelude-ls: 1.2.1
-
-  typed-array-buffer@1.0.3:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-typed-array: 1.1.15
-
-  typed-array-byte-length@1.0.3:
-    dependencies:
-      call-bind: 1.0.8
-      for-each: 0.3.5
-      gopd: 1.2.0
-      has-proto: 1.2.0
-      is-typed-array: 1.1.15
-
-  typed-array-byte-offset@1.0.4:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      for-each: 0.3.5
-      gopd: 1.2.0
-      has-proto: 1.2.0
-      is-typed-array: 1.1.15
-      reflect.getprototypeof: 1.0.10
-
-  typed-array-length@1.0.7:
-    dependencies:
-      call-bind: 1.0.8
-      for-each: 0.3.5
-      gopd: 1.2.0
-      is-typed-array: 1.1.15
-      possible-typed-array-names: 1.1.0
-      reflect.getprototypeof: 1.0.10
-
-  typescript-eslint@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.48.1(@typescript-eslint/parser@8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.48.1(eslint@10.0.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 10.0.0(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   typescript@5.9.3: {}
-
-  unbox-primitive@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-bigints: 1.1.0
-      has-symbols: 1.1.0
-      which-boxed-primitive: 1.1.1
 
   uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
-
-  unrs-resolver@1.11.1:
-    dependencies:
-      napi-postinstall: 0.3.4
-    optionalDependencies:
-      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
-      '@unrs/resolver-binding-android-arm64': 1.11.1
-      '@unrs/resolver-binding-darwin-arm64': 1.11.1
-      '@unrs/resolver-binding-darwin-x64': 1.11.1
-      '@unrs/resolver-binding-freebsd-x64': 1.11.1
-      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
-      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
-      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
-      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
-      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
-      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
-      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
-      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
-      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
   update-browserslist-db@1.2.2(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  uri-js@4.4.1:
-    dependencies:
-      punycode: 2.3.1
 
   use-callback-ref@1.3.3(@types/react@19.2.13)(react@19.2.4):
     dependencies:
@@ -5904,62 +3056,7 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  which-boxed-primitive@1.1.1:
-    dependencies:
-      is-bigint: 1.1.0
-      is-boolean-object: 1.2.2
-      is-number-object: 1.1.1
-      is-string: 1.1.1
-      is-symbol: 1.1.1
-
-  which-builtin-type@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      function.prototype.name: 1.1.8
-      has-tostringtag: 1.0.2
-      is-async-function: 2.1.1
-      is-date-object: 1.1.0
-      is-finalizationregistry: 1.1.1
-      is-generator-function: 1.1.2
-      is-regex: 1.2.1
-      is-weakref: 1.1.1
-      isarray: 2.0.5
-      which-boxed-primitive: 1.1.1
-      which-collection: 1.0.2
-      which-typed-array: 1.1.19
-
-  which-collection@1.0.2:
-    dependencies:
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-weakmap: 2.0.2
-      is-weakset: 2.0.4
-
-  which-typed-array@1.1.19:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
-
-  word-wrap@1.2.5: {}
-
   ws@8.19.0: {}
-
-  yallist@3.1.1: {}
-
-  yocto-queue@0.1.0: {}
-
-  zod-validation-error@4.0.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod@4.3.6: {}
 

--- a/scripts/download-btc-data.ts
+++ b/scripts/download-btc-data.ts
@@ -1,0 +1,144 @@
+import * as fs from 'node:fs';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? '',
+);
+
+interface Candle {
+  timestamp: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+async function fetchFromBinance(startTime: number, endTime: number): Promise<Candle[]> {
+  const allCandles: Candle[] = [];
+  let currentStart = startTime;
+
+  while (currentStart < endTime) {
+    const url = `https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval=1h&startTime=${currentStart}&endTime=${endTime}&limit=1000`;
+
+    console.log(`Fetching from ${new Date(currentStart).toISOString()}...`);
+
+    const response = await fetch(url);
+    const data = await response.json();
+
+    if (!Array.isArray(data) || data.length === 0) {
+      break;
+    }
+
+    const candles = data.map((c: number[]) => ({
+      timestamp: new Date(c[0]).toISOString(),
+      open: Number.parseFloat(String(c[1])),
+      high: Number.parseFloat(String(c[2])),
+      low: Number.parseFloat(String(c[3])),
+      close: Number.parseFloat(String(c[4])),
+      volume: Number.parseFloat(String(c[5])),
+    }));
+
+    allCandles.push(...candles);
+
+    // Move to next batch
+    const lastTimestamp = data[data.length - 1][0];
+    currentStart = lastTimestamp + 1;
+
+    // Small delay to avoid rate limiting
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  return allCandles;
+}
+
+async function main() {
+  const startDate = new Date('2025-11-01T00:00:00Z');
+  const endDate = new Date('2025-12-14T23:59:59Z');
+
+  console.log(
+    `Downloading BTC/USDT 1h data from ${startDate.toISOString()} to ${endDate.toISOString()}`,
+  );
+
+  // Check existing data in Supabase
+  console.log('\nChecking existing data in database...');
+  const { data: existingData, error: checkError } = await supabase
+    .from('market_data')
+    .select('timestamp, open, high, low, close, volume')
+    .eq('asset', 'btcusdt')
+    .gte('timestamp', startDate.toISOString())
+    .lte('timestamp', endDate.toISOString())
+    .order('timestamp', { ascending: true });
+
+  if (checkError) {
+    console.error('Error checking existing data:', checkError);
+  }
+
+  const existingCount = existingData?.length || 0;
+  console.log(`Found ${existingCount} existing records in database`);
+
+  // Fetch from Binance
+  console.log('\nFetching data from Binance...');
+  const binanceData = await fetchFromBinance(startDate.getTime(), endDate.getTime());
+  console.log(`Fetched ${binanceData.length} candles from Binance`);
+
+  // Use Binance data as source of truth (more complete)
+  const candles = binanceData;
+
+  // Store in Supabase (upsert)
+  console.log('\nStoring in Supabase...');
+  const insertData = candles.map((c) => ({
+    asset: 'btcusdt',
+    timestamp: c.timestamp,
+    open: c.open,
+    high: c.high,
+    low: c.low,
+    close: c.close,
+    volume: c.volume,
+    source: 'binance',
+  }));
+
+  // Batch insert in chunks of 500
+  for (let i = 0; i < insertData.length; i += 500) {
+    const batch = insertData.slice(i, i + 500);
+    const { error } = await supabase.from('market_data').upsert(batch, {
+      onConflict: 'asset,timestamp',
+    });
+    if (error) {
+      console.error(`Error inserting batch ${i / 500 + 1}:`, error);
+    } else {
+      console.log(
+        `Inserted batch ${Math.floor(i / 500) + 1}/${Math.ceil(insertData.length / 500)}`,
+      );
+    }
+  }
+
+  // Export to CSV
+  console.log('\nExporting to CSV...');
+  const csvHeader = 'timestamp,open,high,low,close,volume';
+  const csvRows = candles.map(
+    (c) => `${c.timestamp},${c.open},${c.high},${c.low},${c.close},${c.volume}`,
+  );
+  const csvContent = [csvHeader, ...csvRows].join('\n');
+
+  const outputPath = 'data/btcusdt-1h-nov-dec-2025.csv';
+
+  // Ensure data directory exists
+  if (!fs.existsSync('data')) {
+    fs.mkdirSync('data');
+  }
+
+  fs.writeFileSync(outputPath, csvContent);
+  console.log(`\nExported ${candles.length} candles to ${outputPath}`);
+
+  // Summary
+  console.log('\n=== Summary ===');
+  console.log(`Period: ${startDate.toISOString()} to ${endDate.toISOString()}`);
+  console.log(`Total candles: ${candles.length}`);
+  console.log(`First candle: ${candles[0]?.timestamp}`);
+  console.log(`Last candle: ${candles[candles.length - 1]?.timestamp}`);
+  console.log(`Output file: ${outputPath}`);
+}
+
+main().catch(console.error);

--- a/src/app/(dashboard)/assets/page.tsx
+++ b/src/app/(dashboard)/assets/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useMarketStore } from '@/lib/stores/market-store';
-import { useHistoricalData } from '@/lib/hooks/use-market-data';
 import { CandlestickChart } from '@/components/charts/candlestick-chart';
 import { LiveTicker } from '@/components/trading/live-ticker';
 import { TradesTable } from '@/components/trading/trades-table';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useHistoricalData } from '@/lib/hooks/use-market-data';
+import { useMarketStore } from '@/lib/stores/market-store';
+import { useState } from 'react';
 
 const ASSETS = ['btcusdt', 'ethusdt', 'bnbusdt', 'solusdt'];
 
@@ -93,19 +93,23 @@ export default function AssetsPage() {
       )}
 
       {/* Asset Tabs */}
-      <Tabs defaultValue="btc" className="w-full" onValueChange={(val) => {
-        const tab = ASSET_TABS.find(t => t.id === val);
-        if (tab) setSelectedAsset(tab.asset);
-      }}>
+      <Tabs
+        defaultValue="btc"
+        className="w-full"
+        onValueChange={(val) => {
+          const tab = ASSET_TABS.find((t) => t.id === val);
+          if (tab) setSelectedAsset(tab.asset);
+        }}
+      >
         <TabsList>
-          {ASSET_TABS.map(tab => (
+          {ASSET_TABS.map((tab) => (
             <TabsTrigger key={tab.id} value={tab.id}>
               {tab.label}
             </TabsTrigger>
           ))}
         </TabsList>
 
-        {ASSET_TABS.map(tab => (
+        {ASSET_TABS.map((tab) => (
           <TabsContent key={tab.id} value={tab.id} className="space-y-4">
             <div className="grid gap-4 md:grid-cols-3">
               <div className="md:col-span-2 space-y-4">

--- a/src/app/(dashboard)/convert/page.tsx
+++ b/src/app/(dashboard)/convert/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Label } from '@/components/ui/label';
-import { Input } from '@/components/ui/input';
 import { CodeEditor } from '@/components/editors/code-editor';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
 
 const SAMPLE_PYTHON = `# SMA Crossover Strategy
 def calculate_sma(prices, period):
@@ -54,7 +54,9 @@ interface ConversionResult {
 
 export default function ConvertPage() {
   const [pythonCode, setPythonCode] = useState(SAMPLE_PYTHON);
-  const [typescriptCode, setTypescriptCode] = useState('// TypeScript code will appear here after conversion');
+  const [typescriptCode, setTypescriptCode] = useState(
+    '// TypeScript code will appear here after conversion',
+  );
   const [strategyName, setStrategyName] = useState('');
   const [validateCode, setValidateCode] = useState(true);
   const [explainCode, setExplainCode] = useState(true);
@@ -178,9 +180,7 @@ export default function ConvertPage() {
           </Button>
 
           {convertMutation.isError && (
-            <Badge variant="destructive">
-              Error: {convertMutation.error?.message}
-            </Badge>
+            <Badge variant="destructive">Error: {convertMutation.error?.message}</Badge>
           )}
         </div>
       </Card>
@@ -193,7 +193,9 @@ export default function ConvertPage() {
                 <h2 className="mb-4 text-lg font-semibold">Validation</h2>
                 <div className="space-y-3">
                   <div className="flex items-center gap-2">
-                    <Badge variant={conversionResult.validation.isValid ? 'default' : 'destructive'}>
+                    <Badge
+                      variant={conversionResult.validation.isValid ? 'default' : 'destructive'}
+                    >
                       {conversionResult.validation.isValid ? 'Valid' : 'Invalid'}
                     </Badge>
                   </div>
@@ -202,8 +204,8 @@ export default function ConvertPage() {
                     <div>
                       <h3 className="mb-2 text-sm font-medium text-muted-foreground">Issues:</h3>
                       <ul className="list-inside list-disc space-y-1 text-sm">
-                        {conversionResult.validation.issues.map((issue, i) => (
-                          <li key={i} className="text-destructive">
+                        {conversionResult.validation.issues.map((issue) => (
+                          <li key={issue} className="text-destructive">
                             {issue}
                           </li>
                         ))}
@@ -213,10 +215,12 @@ export default function ConvertPage() {
 
                   {conversionResult.validation.suggestions.length > 0 && (
                     <div>
-                      <h3 className="mb-2 text-sm font-medium text-muted-foreground">Suggestions:</h3>
+                      <h3 className="mb-2 text-sm font-medium text-muted-foreground">
+                        Suggestions:
+                      </h3>
                       <ul className="list-inside list-disc space-y-1 text-sm">
-                        {conversionResult.validation.suggestions.map((suggestion, i) => (
-                          <li key={i}>{suggestion}</li>
+                        {conversionResult.validation.suggestions.map((suggestion) => (
+                          <li key={suggestion}>{suggestion}</li>
                         ))}
                       </ul>
                     </div>
@@ -230,10 +234,12 @@ export default function ConvertPage() {
               <div className="space-y-3">
                 {conversionResult.conversion.dependencies.length > 0 && (
                   <div>
-                    <h3 className="mb-2 text-sm font-medium text-muted-foreground">Dependencies:</h3>
+                    <h3 className="mb-2 text-sm font-medium text-muted-foreground">
+                      Dependencies:
+                    </h3>
                     <div className="flex flex-wrap gap-2">
-                      {conversionResult.conversion.dependencies.map((dep, i) => (
-                        <Badge key={i} variant="secondary">
+                      {conversionResult.conversion.dependencies.map((dep) => (
+                        <Badge key={dep} variant="secondary">
                           {dep}
                         </Badge>
                       ))}
@@ -250,7 +256,9 @@ export default function ConvertPage() {
 
                 {conversionResult.conversion.intent && (
                   <div>
-                    <h3 className="mb-2 text-sm font-medium text-muted-foreground">Original Intent:</h3>
+                    <h3 className="mb-2 text-sm font-medium text-muted-foreground">
+                      Original Intent:
+                    </h3>
                     <p className="text-sm">{conversionResult.conversion.intent}</p>
                   </div>
                 )}
@@ -286,14 +294,10 @@ export default function ConvertPage() {
                 {saveStrategyMutation.isPending ? 'Saving...' : 'Save Strategy'}
               </Button>
 
-              {saveStrategyMutation.isSuccess && (
-                <Badge variant="default">Strategy saved!</Badge>
-              )}
+              {saveStrategyMutation.isSuccess && <Badge variant="default">Strategy saved!</Badge>}
 
               {saveStrategyMutation.isError && (
-                <Badge variant="destructive">
-                  Error: {saveStrategyMutation.error?.message}
-                </Badge>
+                <Badge variant="destructive">Error: {saveStrategyMutation.error?.message}</Badge>
               )}
             </div>
             <p className="mt-2 text-sm text-muted-foreground">

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import Link from 'next/link';
-import { useMarketStore } from '@/lib/stores/market-store';
 import { LonaBanner } from '@/components/marketing/lona-banner';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { useMarketStore } from '@/lib/stores/market-store';
+import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
 
 const TRACKED_ASSETS = [
   { id: 'btcusdt', label: 'BTC/USDT' },
@@ -81,16 +81,11 @@ export default function DashboardPage() {
           return (
             <Card key={asset.id} className="p-6">
               <div className="flex flex-col space-y-1">
-                <span className="text-sm font-medium text-muted-foreground">
-                  {asset.label}
-                </span>
+                <span className="text-sm font-medium text-muted-foreground">{asset.label}</span>
                 <span className="text-2xl font-bold">
                   {tickData ? formatPrice(tickData.price) : '$--,---'}
                 </span>
-                <Badge
-                  variant={isConnected ? 'default' : 'secondary'}
-                  className="w-fit"
-                >
+                <Badge variant={isConnected ? 'default' : 'secondary'} className="w-fit">
                   {isConnected ? 'Live' : 'Disconnected'}
                 </Badge>
               </div>
@@ -102,9 +97,7 @@ export default function DashboardPage() {
       <div className="grid gap-4 md:grid-cols-3">
         <Card className="p-6">
           <div className="flex flex-col space-y-1">
-            <span className="text-sm font-medium text-muted-foreground">
-              Portfolio Value
-            </span>
+            <span className="text-sm font-medium text-muted-foreground">Portfolio Value</span>
             <span className="text-2xl font-bold">
               {portfolio ? formatCurrency(portfolio.totalValue) : '$0.00'}
             </span>
@@ -116,9 +109,7 @@ export default function DashboardPage() {
 
         <Card className="p-6">
           <div className="flex flex-col space-y-1">
-            <span className="text-sm font-medium text-muted-foreground">
-              Total P&L
-            </span>
+            <span className="text-sm font-medium text-muted-foreground">Total P&L</span>
             <span
               className={`text-2xl font-bold ${
                 portfolio?.pnl >= 0 ? 'text-green-500' : 'text-red-500'
@@ -128,10 +119,7 @@ export default function DashboardPage() {
                 ? `${portfolio.pnl >= 0 ? '+' : ''}${formatCurrency(portfolio.pnl)}`
                 : '$0.00'}
             </span>
-            <Badge
-              variant={portfolio?.pnl >= 0 ? 'default' : 'destructive'}
-              className="w-fit"
-            >
+            <Badge variant={portfolio?.pnl >= 0 ? 'default' : 'destructive'} className="w-fit">
               {portfolio
                 ? `${portfolio.pnl >= 0 ? '+' : ''}${portfolio.pnlPercent.toFixed(2)}%`
                 : '0.00%'}
@@ -141,9 +129,7 @@ export default function DashboardPage() {
 
         <Card className="p-6">
           <div className="flex flex-col space-y-1">
-            <span className="text-sm font-medium text-muted-foreground">
-              Open Positions
-            </span>
+            <span className="text-sm font-medium text-muted-foreground">Open Positions</span>
             <span className="text-2xl font-bold">{positions.length}</span>
             <Badge variant="outline" className="w-fit">
               {positions.length === 0 ? 'No active trades' : `${positions.length} positions`}

--- a/src/app/(dashboard)/data/page.tsx
+++ b/src/app/(dashboard)/data/page.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -22,6 +20,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 
 const ASSETS = [
   { value: 'btcusdt', label: 'BTC/USDT' },
@@ -163,23 +163,16 @@ export default function DataPage() {
         </div>
 
         <div className="mt-6 flex items-center gap-4">
-          <Button
-            onClick={() => downloadMutation.mutate()}
-            disabled={downloadMutation.isPending}
-          >
+          <Button onClick={() => downloadMutation.mutate()} disabled={downloadMutation.isPending}>
             {downloadMutation.isPending ? 'Downloading...' : 'Download Data'}
           </Button>
 
           {downloadMutation.isSuccess && (
-            <Badge variant="default">
-              Downloaded {downloadMutation.data?.count} candles
-            </Badge>
+            <Badge variant="default">Downloaded {downloadMutation.data?.count} candles</Badge>
           )}
 
           {downloadMutation.isError && (
-            <Badge variant="destructive">
-              Error: {downloadMutation.error?.message}
-            </Badge>
+            <Badge variant="destructive">Error: {downloadMutation.error?.message}</Badge>
           )}
         </div>
       </Card>
@@ -206,28 +199,37 @@ export default function DataPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {previewData.data.map((candle: any, idx: number) => (
-                  <TableRow key={idx}>
-                    <TableCell className="font-mono text-xs">
-                      {formatDate(candle.timestamp)}
-                    </TableCell>
-                    <TableCell className="text-right font-mono">
-                      {parseFloat(candle.open).toFixed(2)}
-                    </TableCell>
-                    <TableCell className="text-right font-mono">
-                      {parseFloat(candle.high).toFixed(2)}
-                    </TableCell>
-                    <TableCell className="text-right font-mono">
-                      {parseFloat(candle.low).toFixed(2)}
-                    </TableCell>
-                    <TableCell className="text-right font-mono">
-                      {parseFloat(candle.close).toFixed(2)}
-                    </TableCell>
-                    <TableCell className="text-right font-mono">
-                      {parseFloat(candle.volume).toFixed(2)}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {previewData.data.map(
+                  (candle: {
+                    timestamp: string;
+                    open: string;
+                    high: string;
+                    low: string;
+                    close: string;
+                    volume: string;
+                  }) => (
+                    <TableRow key={candle.timestamp}>
+                      <TableCell className="font-mono text-xs">
+                        {formatDate(candle.timestamp)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono">
+                        {Number.parseFloat(candle.open).toFixed(2)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono">
+                        {Number.parseFloat(candle.high).toFixed(2)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono">
+                        {Number.parseFloat(candle.low).toFixed(2)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono">
+                        {Number.parseFloat(candle.close).toFixed(2)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono">
+                        {Number.parseFloat(candle.volume).toFixed(2)}
+                      </TableCell>
+                    </TableRow>
+                  ),
+                )}
               </TableBody>
             </Table>
           </div>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,7 +1,7 @@
-import Link from 'next/link';
-import { UserButton } from '@clerk/nextjs';
-import { Button } from '@/components/ui/button';
 import { Logo } from '@/components/logo';
+import { Button } from '@/components/ui/button';
+import { UserButton } from '@clerk/nextjs';
+import Link from 'next/link';
 
 export default function DashboardLayout({
   children,
@@ -85,11 +85,7 @@ export default function DashboardLayout({
             >
               GitHub
             </Link>
-            <Link
-              href="https://lona.agency"
-              target="_blank"
-              className="hover:text-primary"
-            >
+            <Link href="https://lona.agency" target="_blank" className="hover:text-primary">
               Lona
             </Link>
           </div>

--- a/src/app/(dashboard)/live/page.tsx
+++ b/src/app/(dashboard)/live/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import { OrderForm } from '@/components/trading/order-form';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -14,19 +13,26 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { OrderForm } from '@/components/trading/order-form';
 import { useMarketStore } from '@/lib/stores/market-store';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 
 const ASSETS = ['btcusdt', 'ethusdt', 'bnbusdt', 'solusdt'];
 
 export default function LiveTradingPage() {
-  const [selectedBroker, setSelectedBroker] = useState<'binance' | 'bybit' | 'kraken' | 'coinbase'>('bybit');
+  const [selectedBroker, setSelectedBroker] = useState<'binance' | 'bybit' | 'kraken' | 'coinbase'>(
+    'bybit',
+  );
   const [selectedAsset, setSelectedAsset] = useState('BTC/USDT');
   const [useTestnet, setUseTestnet] = useState(true);
   const queryClient = useQueryClient();
   const { tickers } = useMarketStore();
 
-  const { data: brokerData, isLoading, error } = useQuery({
+  const {
+    data: brokerData,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['broker', selectedBroker, selectedAsset, useTestnet],
     queryFn: async () => {
       const params = new URLSearchParams({
@@ -93,8 +99,8 @@ export default function LiveTradingPage() {
         .reduce((sum, [_, amount]) => sum + (amount as number), 0)
     : 0;
 
-  const currentPrice = tickers.get(selectedAsset.toLowerCase().replace('/', ''))?.price ||
-    brokerData?.ticker?.price;
+  const currentPrice =
+    tickers.get(selectedAsset.toLowerCase().replace('/', ''))?.price || brokerData?.ticker?.price;
 
   const isConnected = !error && brokerData;
 
@@ -128,7 +134,10 @@ export default function LiveTradingPage() {
         <div className="grid gap-4 md:grid-cols-3">
           <div className="space-y-2">
             <Label htmlFor="broker">Select Broker</Label>
-            <Select value={selectedBroker} onValueChange={(value: any) => setSelectedBroker(value)}>
+            <Select
+              value={selectedBroker}
+              onValueChange={(value: string) => setSelectedBroker(value as typeof selectedBroker)}
+            >
               <SelectTrigger id="broker">
                 <SelectValue placeholder="Select broker" />
               </SelectTrigger>
@@ -143,7 +152,10 @@ export default function LiveTradingPage() {
 
           <div className="space-y-2">
             <Label htmlFor="environment">Environment</Label>
-            <Select value={useTestnet ? 'testnet' : 'live'} onValueChange={(val) => setUseTestnet(val === 'testnet')}>
+            <Select
+              value={useTestnet ? 'testnet' : 'live'}
+              onValueChange={(val) => setUseTestnet(val === 'testnet')}
+            >
               <SelectTrigger id="environment">
                 <SelectValue />
               </SelectTrigger>
@@ -183,9 +195,7 @@ export default function LiveTradingPage() {
             <span className="text-sm font-medium text-muted-foreground">
               Available Balance (USDT)
             </span>
-            <span className="text-2xl font-bold">
-              {formatCurrency(totalBalance)}
-            </span>
+            <span className="text-2xl font-bold">{formatCurrency(totalBalance)}</span>
             <Badge variant="outline" className="w-fit">
               {selectedBroker.toUpperCase()} {useTestnet ? 'Testnet' : 'Live'}
             </Badge>
@@ -194,9 +204,7 @@ export default function LiveTradingPage() {
 
         <Card className="p-6">
           <div className="flex flex-col space-y-1">
-            <span className="text-sm font-medium text-muted-foreground">
-              Current Price
-            </span>
+            <span className="text-sm font-medium text-muted-foreground">Current Price</span>
             <span className="text-2xl font-bold">
               {currentPrice ? formatCurrency(currentPrice) : '$--,---'}
             </span>
@@ -208,14 +216,12 @@ export default function LiveTradingPage() {
 
         <Card className="p-6">
           <div className="flex flex-col space-y-1">
-            <span className="text-sm font-medium text-muted-foreground">
-              Open Orders
-            </span>
-            <span className="text-2xl font-bold">
-              {brokerData?.openOrders?.length || 0}
-            </span>
+            <span className="text-sm font-medium text-muted-foreground">Open Orders</span>
+            <span className="text-2xl font-bold">{brokerData?.openOrders?.length || 0}</span>
             <Badge variant="outline" className="w-fit">
-              {brokerData?.openOrders?.length ? `${brokerData.openOrders.length} active` : 'No orders'}
+              {brokerData?.openOrders?.length
+                ? `${brokerData.openOrders.length} active`
+                : 'No orders'}
             </Badge>
           </div>
         </Card>
@@ -226,7 +232,10 @@ export default function LiveTradingPage() {
           <h2 className="mb-4 text-xl font-semibold">Account Balances</h2>
           <div className="grid gap-3 md:grid-cols-4">
             {Object.entries(brokerData.balance).map(([currency, amount]) => (
-              <div key={currency} className="flex items-center justify-between p-3 rounded-lg border">
+              <div
+                key={currency}
+                className="flex items-center justify-between p-3 rounded-lg border"
+              >
                 <span className="text-sm font-medium">{currency}</span>
                 <span className="font-mono text-sm">{(amount as number).toFixed(8)}</span>
               </div>
@@ -241,27 +250,37 @@ export default function LiveTradingPage() {
             <Card className="p-4">
               <h3 className="text-lg font-semibold mb-4">Open Orders</h3>
               <div className="space-y-2">
-                {brokerData.openOrders.map((order: any) => (
-                  <div
-                    key={order.id}
-                    className="flex items-center justify-between p-3 rounded-lg border"
-                  >
-                    <div className="flex items-center gap-3">
-                      <Badge variant={order.side === 'buy' ? 'default' : 'destructive'}>
-                        {order.side.toUpperCase()}
-                      </Badge>
-                      <span className="font-medium">{order.symbol}</span>
-                    </div>
-                    <div className="text-right">
-                      <div className="font-mono text-sm">
-                        {order.amount} @ {formatCurrency(order.price)}
+                {brokerData.openOrders.map(
+                  (order: {
+                    id: string;
+                    side: string;
+                    symbol: string;
+                    amount: number;
+                    price: number;
+                    type: string;
+                    status: string;
+                  }) => (
+                    <div
+                      key={order.id}
+                      className="flex items-center justify-between p-3 rounded-lg border"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Badge variant={order.side === 'buy' ? 'default' : 'destructive'}>
+                          {order.side.toUpperCase()}
+                        </Badge>
+                        <span className="font-medium">{order.symbol}</span>
                       </div>
-                      <div className="text-xs text-muted-foreground">
-                        {order.type} - {order.status}
+                      <div className="text-right">
+                        <div className="font-mono text-sm">
+                          {order.amount} @ {formatCurrency(order.price)}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {order.type} - {order.status}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                ))}
+                  ),
+                )}
               </div>
             </Card>
           )}
@@ -269,9 +288,7 @@ export default function LiveTradingPage() {
           {(!brokerData?.openOrders || brokerData.openOrders.length === 0) && (
             <Card className="p-12 text-center">
               <p className="text-muted-foreground">No open orders</p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Place an order to see it here
-              </p>
+              <p className="text-xs text-muted-foreground mt-1">Place an order to see it here</p>
             </Card>
           )}
         </div>

--- a/src/app/(dashboard)/paper/page.tsx
+++ b/src/app/(dashboard)/paper/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import { OrderForm } from '@/components/trading/order-form';
+import { PositionsCard } from '@/components/trading/positions-card';
+import { TradesTable } from '@/components/trading/trades-table';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import {
   Select,
   SelectContent,
@@ -12,10 +13,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { OrderForm } from '@/components/trading/order-form';
-import { PositionsCard } from '@/components/trading/positions-card';
-import { TradesTable } from '@/components/trading/trades-table';
 import { useMarketStore } from '@/lib/stores/market-store';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 
 const ASSETS = ['btcusdt', 'ethusdt', 'bnbusdt', 'solusdt'];
 
@@ -99,7 +99,7 @@ export default function PaperTradingPage() {
   const handleCreatePortfolio = () => {
     const balance = prompt('Enter initial balance (default: $10,000):', '10000');
     if (balance) {
-      createPortfolioMutation.mutate(parseFloat(balance));
+      createPortfolioMutation.mutate(Number.parseFloat(balance));
     }
   };
 
@@ -117,9 +117,7 @@ export default function PaperTradingPage() {
       <div className="space-y-6">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Paper Trading</h1>
-          <p className="text-muted-foreground">
-            Test strategies risk-free with simulated accounts
-          </p>
+          <p className="text-muted-foreground">Test strategies risk-free with simulated accounts</p>
         </div>
 
         <Card className="p-12 text-center">
@@ -127,10 +125,7 @@ export default function PaperTradingPage() {
           <p className="text-muted-foreground mb-6">
             Create a paper trading portfolio to start simulated trading
           </p>
-          <Button
-            onClick={handleCreatePortfolio}
-            disabled={createPortfolioMutation.isPending}
-          >
+          <Button onClick={handleCreatePortfolio} disabled={createPortfolioMutation.isPending}>
             {createPortfolioMutation.isPending ? 'Creating...' : 'Create Portfolio'}
           </Button>
         </Card>
@@ -143,20 +138,13 @@ export default function PaperTradingPage() {
       <div className="space-y-6">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Paper Trading</h1>
-          <p className="text-muted-foreground">
-            Test strategies risk-free with simulated accounts
-          </p>
+          <p className="text-muted-foreground">Test strategies risk-free with simulated accounts</p>
         </div>
 
         <Card className="p-12 text-center">
           <h2 className="text-xl font-semibold mb-4">Get Started</h2>
-          <p className="text-muted-foreground mb-6">
-            Create your first paper trading portfolio
-          </p>
-          <Button
-            onClick={handleCreatePortfolio}
-            disabled={createPortfolioMutation.isPending}
-          >
+          <p className="text-muted-foreground mb-6">Create your first paper trading portfolio</p>
+          <Button onClick={handleCreatePortfolio} disabled={createPortfolioMutation.isPending}>
             {createPortfolioMutation.isPending ? 'Creating...' : 'Create Portfolio'}
           </Button>
         </Card>
@@ -177,9 +165,7 @@ export default function PaperTradingPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Paper Trading</h1>
-          <p className="text-muted-foreground">
-            Test strategies risk-free with simulated accounts
-          </p>
+          <p className="text-muted-foreground">Test strategies risk-free with simulated accounts</p>
         </div>
         <Button onClick={handleCreatePortfolio} variant="outline">
           New Portfolio
@@ -189,15 +175,12 @@ export default function PaperTradingPage() {
       {portfolios.length > 1 && (
         <div className="flex items-center gap-2">
           <span className="text-sm text-muted-foreground">Portfolio:</span>
-          <Select
-            value={selectedPortfolio || ''}
-            onValueChange={setSelectedPortfolio}
-          >
+          <Select value={selectedPortfolio || ''} onValueChange={setSelectedPortfolio}>
             <SelectTrigger className="w-[200px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {portfolios.map((p: any) => (
+              {portfolios.map((p: { id: string; balance: number }) => (
                 <SelectItem key={p.id} value={p.id}>
                   {formatCurrency(p.balance)}
                 </SelectItem>
@@ -212,12 +195,8 @@ export default function PaperTradingPage() {
           <div className="grid gap-4 md:grid-cols-3">
             <Card className="p-6">
               <div className="flex flex-col space-y-1">
-                <span className="text-sm font-medium text-muted-foreground">
-                  Total Value
-                </span>
-                <span className="text-2xl font-bold">
-                  {formatCurrency(portfolio.totalValue)}
-                </span>
+                <span className="text-sm font-medium text-muted-foreground">Total Value</span>
+                <span className="text-2xl font-bold">{formatCurrency(portfolio.totalValue)}</span>
                 <Badge variant="outline" className="w-fit">
                   Cash: {formatCurrency(portfolio.balance)}
                 </Badge>
@@ -226,9 +205,7 @@ export default function PaperTradingPage() {
 
             <Card className="p-6">
               <div className="flex flex-col space-y-1">
-                <span className="text-sm font-medium text-muted-foreground">
-                  Total P&L
-                </span>
+                <span className="text-sm font-medium text-muted-foreground">Total P&L</span>
                 <span
                   className={`text-2xl font-bold ${
                     portfolio.pnl >= 0 ? 'text-green-500' : 'text-red-500'
@@ -237,10 +214,7 @@ export default function PaperTradingPage() {
                   {portfolio.pnl >= 0 ? '+' : ''}
                   {formatCurrency(portfolio.pnl)}
                 </span>
-                <Badge
-                  variant={portfolio.pnl >= 0 ? 'default' : 'destructive'}
-                  className="w-fit"
-                >
+                <Badge variant={portfolio.pnl >= 0 ? 'default' : 'destructive'} className="w-fit">
                   {portfolio.pnl >= 0 ? '+' : ''}
                   {portfolio.pnlPercent.toFixed(2)}%
                 </Badge>
@@ -249,9 +223,7 @@ export default function PaperTradingPage() {
 
             <Card className="p-6">
               <div className="flex flex-col space-y-1">
-                <span className="text-sm font-medium text-muted-foreground">
-                  Open Positions
-                </span>
+                <span className="text-sm font-medium text-muted-foreground">Open Positions</span>
                 <span className="text-2xl font-bold">{positions.length}</span>
                 <Badge variant="outline" className="w-fit">
                   {positions.length === 0 ? 'No active trades' : `${trades.length} total trades`}
@@ -272,29 +244,38 @@ export default function PaperTradingPage() {
                   </div>
                 ) : (
                   <div className="space-y-2">
-                    {trades.slice(0, 10).map((trade: any) => (
-                      <div
-                        key={trade.id}
-                        className="flex items-center justify-between p-3 rounded-lg border"
-                      >
-                        <div className="flex items-center gap-3">
-                          <Badge variant={trade.side === 'buy' ? 'default' : 'destructive'}>
-                            {trade.side.toUpperCase()}
-                          </Badge>
-                          <span className="font-medium uppercase">
-                            {trade.asset.replace('usdt', '/USDT')}
-                          </span>
-                        </div>
-                        <div className="text-right">
-                          <div className="font-mono">
-                            {trade.amount} @ {formatCurrency(trade.price)}
+                    {trades.slice(0, 10).map(
+                      (trade: {
+                        id: string;
+                        side: string;
+                        asset: string;
+                        amount: number;
+                        price: number;
+                        created_at: string;
+                      }) => (
+                        <div
+                          key={trade.id}
+                          className="flex items-center justify-between p-3 rounded-lg border"
+                        >
+                          <div className="flex items-center gap-3">
+                            <Badge variant={trade.side === 'buy' ? 'default' : 'destructive'}>
+                              {trade.side.toUpperCase()}
+                            </Badge>
+                            <span className="font-medium uppercase">
+                              {trade.asset.replace('usdt', '/USDT')}
+                            </span>
                           </div>
-                          <div className="text-xs text-muted-foreground">
-                            {new Date(trade.created_at).toLocaleString()}
+                          <div className="text-right">
+                            <div className="font-mono">
+                              {trade.amount} @ {formatCurrency(trade.price)}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {new Date(trade.created_at).toLocaleString()}
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    ))}
+                      ),
+                    )}
                   </div>
                 )}
               </Card>

--- a/src/app/(dashboard)/strategies/[id]/page.tsx
+++ b/src/app/(dashboard)/strategies/[id]/page.tsx
@@ -1,14 +1,11 @@
 'use client';
 
-import { useState, use } from 'react';
-import { useRouter } from 'next/navigation';
-import Link from 'next/link';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import { CodeEditor } from '@/components/editors/code-editor';
 import { Badge } from '@/components/ui/badge';
-import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -16,15 +13,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { CodeEditor } from '@/components/editors/code-editor';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
+  useDeleteStrategy,
+  useStartStrategy,
+  useStopStrategy,
   useStrategy,
   useStrategyLogs,
   useUpdateStrategy,
-  useStartStrategy,
-  useStopStrategy,
-  useDeleteStrategy,
 } from '@/lib/hooks/use-strategies';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { use, useState } from 'react';
 
 const STATUS_COLORS: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   draft: 'secondary',
@@ -126,11 +126,7 @@ export default function StrategyDetailPage({
   };
 
   if (isLoading) {
-    return (
-      <div className="py-12 text-center text-muted-foreground">
-        Loading strategy...
-      </div>
-    );
+    return <div className="py-12 text-center text-muted-foreground">Loading strategy...</div>;
   }
 
   if (error || !data?.strategy) {
@@ -162,11 +158,7 @@ export default function StrategyDetailPage({
         </div>
         <div className="flex items-center gap-2">
           {strategy.status === 'running' ? (
-            <Button
-              variant="destructive"
-              onClick={handleStop}
-              disabled={stopMutation.isPending}
-            >
+            <Button variant="destructive" onClick={handleStop} disabled={stopMutation.isPending}>
               {stopMutation.isPending ? 'Stopping...' : 'Stop'}
             </Button>
           ) : (
@@ -234,9 +226,7 @@ export default function StrategyDetailPage({
               <Button onClick={handleSave} disabled={updateMutation.isPending}>
                 {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
               </Button>
-              {updateMutation.isSuccess && (
-                <Badge variant="default">Changes saved!</Badge>
-              )}
+              {updateMutation.isSuccess && <Badge variant="default">Changes saved!</Badge>}
             </div>
           )}
         </TabsContent>
@@ -335,8 +325,8 @@ export default function StrategyDetailPage({
             <Card className="p-6">
               <h2 className="mb-4 text-lg font-semibold">Dependencies</h2>
               <div className="flex flex-wrap gap-2">
-                {strategy.dependencies.map((dep: string, i: number) => (
-                  <Badge key={i} variant="secondary">
+                {strategy.dependencies.map((dep: string) => (
+                  <Badge key={dep} variant="secondary">
                     {dep}
                   </Badge>
                 ))}
@@ -350,10 +340,7 @@ export default function StrategyDetailPage({
             <Card className="p-6">
               <div className="flex flex-col space-y-1">
                 <span className="text-sm font-medium text-muted-foreground">Status</span>
-                <Badge
-                  variant={STATUS_COLORS[strategy.status]}
-                  className="w-fit text-lg"
-                >
+                <Badge variant={STATUS_COLORS[strategy.status]} className="w-fit text-lg">
                   {strategy.status.toUpperCase()}
                 </Badge>
               </div>
@@ -363,9 +350,7 @@ export default function StrategyDetailPage({
               <div className="flex flex-col space-y-1">
                 <span className="text-sm font-medium text-muted-foreground">Last Run</span>
                 <span className="text-lg font-semibold">
-                  {strategy.last_run_at
-                    ? new Date(strategy.last_run_at).toLocaleString()
-                    : 'Never'}
+                  {strategy.last_run_at ? new Date(strategy.last_run_at).toLocaleString() : 'Never'}
                 </span>
               </div>
             </Card>
@@ -414,11 +399,7 @@ export default function StrategyDetailPage({
 
           <div className="flex items-center gap-4">
             {strategy.status === 'running' ? (
-              <Button
-                variant="destructive"
-                onClick={handleStop}
-                disabled={stopMutation.isPending}
-              >
+              <Button variant="destructive" onClick={handleStop} disabled={stopMutation.isPending}>
                 {stopMutation.isPending ? 'Stopping...' : 'Stop Strategy'}
               </Button>
             ) : (

--- a/src/app/(dashboard)/strategies/page.tsx
+++ b/src/app/(dashboard)/strategies/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 
 interface Strategy {
   id: string;
@@ -47,9 +47,7 @@ export default function StrategiesPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Strategies</h1>
-          <p className="text-muted-foreground">
-            Manage and monitor your trading strategies
-          </p>
+          <p className="text-muted-foreground">Manage and monitor your trading strategies</p>
         </div>
         <Link href="/dashboard/convert">
           <Button>New Strategy</Button>
@@ -91,9 +89,7 @@ export default function StrategiesPage() {
                       </p>
                     )}
                   </div>
-                  <Badge variant={STATUS_COLORS[strategy.status]}>
-                    {strategy.status}
-                  </Badge>
+                  <Badge variant={STATUS_COLORS[strategy.status]}>{strategy.status}</Badge>
                 </div>
                 <div className="mt-4 flex items-center gap-4 text-sm text-muted-foreground">
                   <span>{strategy.asset.toUpperCase()}</span>

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,9 +1,9 @@
-import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Logo } from '@/components/logo';
 import { LonaBanner } from '@/components/marketing/lona-banner';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import Link from 'next/link';
 
 export default function LandingPage() {
   return (
@@ -59,6 +59,7 @@ export default function LandingPage() {
             href="https://lona.agency"
             target="_blank"
             className="font-medium text-primary underline-offset-4 hover:underline"
+            rel="noreferrer"
           >
             Lona.agency
           </a>
@@ -94,8 +95,8 @@ export default function LandingPage() {
           <Card className="p-6">
             <h3 className="mb-2 text-xl font-semibold">Real-Time Data</h3>
             <p className="text-muted-foreground">
-              WebSocket feeds with tick + 1-min historical storage in Supabase. Lightning-fast
-              Redis caching.
+              WebSocket feeds with tick + 1-min historical storage in Supabase. Lightning-fast Redis
+              caching.
             </p>
           </Card>
           <Card className="p-6">
@@ -162,11 +163,7 @@ export default function LandingPage() {
             >
               GitHub
             </Link>
-            <Link
-              href="https://lona.agency"
-              target="_blank"
-              className="hover:text-primary"
-            >
+            <Link href="https://lona.agency" target="_blank" className="hover:text-primary">
               Lona
             </Link>
           </div>

--- a/src/app/api/broker/route.ts
+++ b/src/app/api/broker/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@clerk/nextjs/server';
 import {
-  createBrokerClient,
-  getDefaultBrokerCredentials,
   type BrokerName,
   type OrderParams,
+  createBrokerClient,
+  getDefaultBrokerCredentials,
 } from '@/lib/broker';
+import { auth } from '@clerk/nextjs/server';
+import { type NextRequest, NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
 
@@ -50,7 +50,7 @@ export async function GET(request: NextRequest) {
       {
         error: error instanceof Error ? error.message : 'Failed to fetch broker data',
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -67,24 +67,22 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { broker = 'bybit', testnet = true, order } = body as {
+    const {
+      broker = 'bybit',
+      testnet = true,
+      order,
+    } = body as {
       broker?: BrokerName;
       testnet?: boolean;
       order: OrderParams;
     };
 
     if (!order || !order.symbol || !order.side || !order.type || !order.amount) {
-      return NextResponse.json(
-        { error: 'Missing required order parameters' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Missing required order parameters' }, { status: 400 });
     }
 
     if (order.type === 'limit' && !order.price) {
-      return NextResponse.json(
-        { error: 'Price is required for limit orders' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Price is required for limit orders' }, { status: 400 });
     }
 
     const credentials = getDefaultBrokerCredentials(broker);
@@ -107,7 +105,7 @@ export async function POST(request: NextRequest) {
       {
         error: error instanceof Error ? error.message : 'Failed to place order',
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -130,10 +128,7 @@ export async function DELETE(request: NextRequest) {
     const testnet = searchParams.get('testnet') !== 'false';
 
     if (!orderId || !symbol) {
-      return NextResponse.json(
-        { error: 'Missing orderId or symbol' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Missing orderId or symbol' }, { status: 400 });
     }
 
     const credentials = getDefaultBrokerCredentials(broker);
@@ -157,7 +152,7 @@ export async function DELETE(request: NextRequest) {
       {
         error: error instanceof Error ? error.message : 'Failed to cancel order',
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/convert/route.ts
+++ b/src/app/api/convert/route.ts
@@ -1,6 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { convertPythonToTypescript, validateTypescriptCode, explainStrategy } from '@/lib/ai-convert';
+import {
+  convertPythonToTypescript,
+  explainStrategy,
+  validateTypescriptCode,
+} from '@/lib/ai-convert';
 import { flushTraces } from '@/lib/langsmith';
+import { type NextRequest, NextResponse } from 'next/server';
 
 /**
  * API Route: /api/convert
@@ -16,7 +20,7 @@ export async function POST(request: NextRequest) {
     if (!pythonCode) {
       return NextResponse.json(
         { error: 'Missing required parameter: pythonCode' },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -65,7 +69,7 @@ export async function POST(request: NextRequest) {
         error: 'Failed to convert Python code',
         message: error instanceof Error ? error.message : String(error),
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/cron/strategies/route.ts
+++ b/src/app/api/cron/strategies/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { logStrategyEvent, runStrategy } from '@/lib/strategy/executor';
 import { supabaseAdmin } from '@/lib/supabase';
-import { runStrategy, logStrategyEvent } from '@/lib/strategy/executor';
 import type { Strategy, StrategyResult } from '@/lib/types/strategy';
+import { type NextRequest, NextResponse } from 'next/server';
 
 /**
  * Vercel Cron Job: /api/cron/strategies
@@ -124,7 +124,7 @@ export async function GET(request: NextRequest) {
     console.error('Cron job error:', error);
     return NextResponse.json(
       { error: 'Cron job failed', message: error instanceof Error ? error.message : String(error) },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -162,7 +162,7 @@ async function executeTrade(strategy: Strategy, result: StrategyResult): Promise
       return;
     }
 
-    const currentPrice = parseFloat(latestCandle.close);
+    const currentPrice = Number.parseFloat(latestCandle.close);
     const amount = result.amount || 0.001; // Default small amount for paper trading
     const total = currentPrice * amount;
 
@@ -207,7 +207,7 @@ async function executeTrade(strategy: Strategy, result: StrategyResult): Promise
         price: currentPrice,
         total,
         reason: result.reason,
-      }
+      },
     );
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/app/api/execute/route.ts
+++ b/src/app/api/execute/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { executePythonCode, validatePythonSyntax } from '@/lib/python-executor';
+import { type NextRequest, NextResponse } from 'next/server';
 
 /**
  * API Route: /api/execute
@@ -15,10 +15,7 @@ export async function POST(request: NextRequest) {
     const { code, inputs } = await request.json();
 
     if (!code) {
-      return NextResponse.json(
-        { error: 'Missing required parameter: code' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Missing required parameter: code' }, { status: 400 });
     }
 
     // Validate Python syntax
@@ -30,7 +27,7 @@ export async function POST(request: NextRequest) {
           error: 'Invalid Python code',
           validationErrors: validation.errors,
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -56,7 +53,7 @@ export async function POST(request: NextRequest) {
         error: 'Failed to execute Python code',
         message: error instanceof Error ? error.message : String(error),
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -68,8 +65,7 @@ export async function GET() {
   return NextResponse.json({
     endpoint: '/api/execute',
     method: 'POST',
-    description:
-      'Execute Python trading code (currently recommends conversion to TypeScript)',
+    description: 'Execute Python trading code (currently recommends conversion to TypeScript)',
     parameters: {
       code: {
         type: 'string',

--- a/src/app/api/strategies/[id]/logs/route.ts
+++ b/src/app/api/strategies/[id]/logs/route.ts
@@ -1,21 +1,18 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { getAuthUserId } from '@/lib/service-auth';
 import { supabaseAdmin } from '@/lib/supabase';
+import { type NextRequest, NextResponse } from 'next/server';
 
 /**
  * GET /api/strategies/[id]/logs - Get logs for a strategy (paginated)
  */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const userId = await getAuthUserId(request);
 
     const { id } = await params;
     const { searchParams } = new URL(request.url);
-    const limit = parseInt(searchParams.get('limit') || '100');
-    const offset = parseInt(searchParams.get('offset') || '0');
+    const limit = Number.parseInt(searchParams.get('limit') || '100');
+    const offset = Number.parseInt(searchParams.get('offset') || '0');
     const level = searchParams.get('level');
 
     // Verify ownership

--- a/src/app/api/strategies/route.ts
+++ b/src/app/api/strategies/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { getAuthUserId } from '@/lib/service-auth';
 import { supabaseAdmin } from '@/lib/supabase';
 import type { CreateStrategyInput, UpdateStrategyInput } from '@/lib/types/strategy';
+import { type NextRequest, NextResponse } from 'next/server';
 
 /**
  * GET /api/strategies - List user's strategies
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
     if (!body.name || !body.python_code || !body.typescript_code) {
       return NextResponse.json(
         { error: 'Missing required fields: name, python_code, typescript_code' },
-        { status: 400 }
+        { status: 400 },
       );
     }
 

--- a/src/app/api/stream/route.ts
+++ b/src/app/api/stream/route.ts
@@ -13,7 +13,7 @@ export const dynamic = 'force-dynamic';
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const assetsParam = searchParams.get('assets') || 'btcusdt,ethusdt';
-  const assets = assetsParam.split(',').map(a => a.trim().toLowerCase());
+  const assets = assetsParam.split(',').map((a) => a.trim().toLowerCase());
 
   // Create SSE response
   const encoder = new TextEncoder();
@@ -26,7 +26,7 @@ export async function GET(request: Request) {
       const initialData = `data: ${JSON.stringify({
         type: 'connected',
         assets,
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       })}\n\n`;
       controller.enqueue(encoder.encode(initialData));
 
@@ -57,7 +57,7 @@ export async function GET(request: Request) {
                 };
               }
               return null;
-            })
+            }),
           );
 
           // Send updates for changed prices
@@ -66,7 +66,7 @@ export async function GET(request: Request) {
               const sseMessage = `data: ${JSON.stringify({
                 type: 'ticker',
                 ...update,
-                timestamp: new Date().toISOString()
+                timestamp: new Date().toISOString(),
               })}\n\n`;
               controller.enqueue(encoder.encode(sseMessage));
             }
@@ -86,7 +86,7 @@ export async function GET(request: Request) {
         try {
           const heartbeatMessage = `data: ${JSON.stringify({
             type: 'heartbeat',
-            timestamp: new Date().toISOString()
+            timestamp: new Date().toISOString(),
           })}\n\n`;
           controller.enqueue(encoder.encode(heartbeatMessage));
         } catch (error) {
@@ -108,7 +108,7 @@ export async function GET(request: Request) {
     headers: {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache, no-transform',
-      'Connection': 'keep-alive',
+      Connection: 'keep-alive',
       'X-Accel-Buffering': 'no', // Disable buffering for Nginx
     },
   });

--- a/src/app/api/websocket/route.ts
+++ b/src/app/api/websocket/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getBinanceWSClient, type Asset } from '@/lib/binance';
+import { type Asset, getBinanceWSClient } from '@/lib/binance';
+import { type NextRequest, NextResponse } from 'next/server';
 
 /**
  * API Route: /api/websocket
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
     if (!assets || !Array.isArray(assets)) {
       return NextResponse.json(
         { error: 'Invalid assets parameter. Expected array of asset symbols.' },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -30,10 +30,7 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error('WebSocket connection error:', error);
-    return NextResponse.json(
-      { error: 'Failed to start WebSocket connection' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to start WebSocket connection' }, { status: 500 });
   }
 }
 
@@ -51,9 +48,6 @@ export async function DELETE() {
     });
   } catch (error) {
     console.error('WebSocket disconnect error:', error);
-    return NextResponse.json(
-      { error: 'Failed to disconnect WebSocket' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to disconnect WebSocket' }, { status: 500 });
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
+import { QueryProvider } from '@/components/providers/query-provider';
+import { ClerkProvider } from '@clerk/nextjs';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import { ClerkProvider } from '@clerk/nextjs';
-import { QueryProvider } from '@/components/providers/query-provider';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });

--- a/src/cli/batch-convert.ts
+++ b/src/cli/batch-convert.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { readdirSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 function convertUnixToISO(unix: number): string {
   const unixMs = unix > 9999999999999 ? Math.floor(unix / 1000) : unix;
@@ -10,17 +10,19 @@ function convertUnixToISO(unix: number): string {
 
 function convertCSV(inputPath: string, symbol: string, outputPath: string) {
   const input = readFileSync(inputPath, 'utf-8');
-  const lines = input.split('\n').filter(line => line.trim());
+  const lines = input.split('\n').filter((line) => line.trim());
   const dataLines = lines.slice(1);
 
   const lonaHeader = 'Timestamp,Symbol,Open,High,Low,Close,Volume\n';
-  const lonaRows = dataLines.map(line => {
-    const parts = line.split(',');
-    const [open_time, open, high, low, close, volume] = parts;
-    const timestamp = convertUnixToISO(parseInt(open_time));
-    const symbolName = `${symbol.toUpperCase()}-PERPETUAL`;
-    return `${timestamp},${symbolName},${open},${high},${low},${close},${volume}`;
-  }).join('\n');
+  const lonaRows = dataLines
+    .map((line) => {
+      const parts = line.split(',');
+      const [open_time, open, high, low, close, volume] = parts;
+      const timestamp = convertUnixToISO(Number.parseInt(open_time));
+      const symbolName = `${symbol.toUpperCase()}-PERPETUAL`;
+      return `${timestamp},${symbolName},${open},${high},${low},${close},${volume}`;
+    })
+    .join('\n');
 
   writeFileSync(outputPath, lonaHeader + lonaRows);
   return dataLines.length;
@@ -32,7 +34,7 @@ const symbol = process.argv[3] || 'btcusdt';
 console.log(`🔄 Converting all CSV files in ${dir}...`);
 
 const files = readdirSync(dir)
-  .filter(f => f.endsWith('.csv') && !f.endsWith('-lona.csv'))
+  .filter((f) => f.endsWith('.csv') && !f.endsWith('-lona.csv'))
   .sort();
 
 let count = 0;

--- a/src/cli/convert-binance-csv.ts
+++ b/src/cli/convert-binance-csv.ts
@@ -13,8 +13,8 @@
  *   pnpm tsx src/cli/convert-binance-csv.ts data/binance/btcusdt/1m/BTCUSDT-1m-2025-10.csv btcusdt
  */
 
-import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 function convertUnixToISO(unix: number): string {
   // Binance Data Portal uses microseconds (16 digits), convert to milliseconds (13 digits)
@@ -26,7 +26,7 @@ function convertCSV(inputPath: string, symbol: string, outputPath?: string) {
   console.log(`📄 Reading: ${inputPath}`);
 
   const input = readFileSync(inputPath, 'utf-8');
-  const lines = input.split('\n').filter(line => line.trim());
+  const lines = input.split('\n').filter((line) => line.trim());
 
   // Skip header line
   const dataLines = lines.slice(1);
@@ -35,15 +35,17 @@ function convertCSV(inputPath: string, symbol: string, outputPath?: string) {
 
   // Convert to Lona format
   const lonaHeader = 'Timestamp,Symbol,Open,High,Low,Close,Volume\n';
-  const lonaRows = dataLines.map(line => {
-    const parts = line.split(',');
-    const [open_time, open, high, low, close, volume] = parts;
+  const lonaRows = dataLines
+    .map((line) => {
+      const parts = line.split(',');
+      const [open_time, open, high, low, close, volume] = parts;
 
-    const timestamp = convertUnixToISO(parseInt(open_time));
-    const symbolName = `${symbol.toUpperCase()}-PERPETUAL`;
+      const timestamp = convertUnixToISO(Number.parseInt(open_time));
+      const symbolName = `${symbol.toUpperCase()}-PERPETUAL`;
 
-    return `${timestamp},${symbolName},${open},${high},${low},${close},${volume}`;
-  }).join('\n');
+      return `${timestamp},${symbolName},${open},${high},${low},${close},${volume}`;
+    })
+    .join('\n');
 
   const output = lonaHeader + lonaRows;
 
@@ -63,7 +65,9 @@ function convertCSV(inputPath: string, symbol: string, outputPath?: string) {
 const args = process.argv.slice(2);
 if (args.length < 2) {
   console.error('Usage: pnpm tsx src/cli/convert-binance-csv.ts <input-csv> <symbol> [output-csv]');
-  console.error('Example: pnpm tsx src/cli/convert-binance-csv.ts data/binance/btcusdt/1m/BTCUSDT-1m-2025-10.csv btcusdt');
+  console.error(
+    'Example: pnpm tsx src/cli/convert-binance-csv.ts data/binance/btcusdt/1m/BTCUSDT-1m-2025-10.csv btcusdt',
+  );
   process.exit(1);
 }
 

--- a/src/cli/merge-csv.ts
+++ b/src/cli/merge-csv.ts
@@ -10,8 +10,8 @@
  *   pnpm tsx src/cli/merge-csv.ts data/binance/btcusdt/1m/BTCUSDT-1m-2025-10-to-11-lona.csv data/binance/btcusdt/1m/*-lona.csv
  */
 
-import { readFileSync, writeFileSync, readdirSync } from 'fs';
-import { join, dirname } from 'path';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 interface CandleRow {
   timestamp: string;
@@ -28,8 +28,8 @@ function mergeCSVFiles(outputPath: string, pattern: string) {
   // Find all matching files
   const allFiles = readdirSync(dir);
   const files = allFiles
-    .filter(f => f.endsWith('-lona.csv'))
-    .map(f => join(dir, f))
+    .filter((f) => f.endsWith('-lona.csv'))
+    .map((f) => join(dir, f))
     .sort();
 
   if (files.length === 0) {
@@ -46,7 +46,7 @@ function mergeCSVFiles(outputPath: string, pattern: string) {
   for (const file of files) {
     console.log(`  Reading: ${file}`);
     const content = readFileSync(file, 'utf-8');
-    const lines = content.split('\n').filter(line => line.trim());
+    const lines = content.split('\n').filter((line) => line.trim());
 
     // Get header from first file
     if (!header && lines.length > 0) {
@@ -64,16 +64,18 @@ function mergeCSVFiles(outputPath: string, pattern: string) {
   console.log(`✓ Total rows collected: ${allRows.length}`);
 
   // Sort by timestamp
-  console.log(`🔄 Sorting by timestamp...`);
+  console.log('🔄 Sorting by timestamp...');
   allRows.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 
   // Write merged file
-  const output = header + '\n' + allRows.map(row => row.line).join('\n');
+  const output = `${header}\n${allRows.map((row) => row.line).join('\n')}`;
   writeFileSync(outputPath, output);
 
   console.log(`\n✅ Merged file created: ${outputPath}`);
   console.log(`📊 Total candles: ${allRows.length}`);
-  console.log(`📅 Date range: ${allRows[0]?.timestamp} to ${allRows[allRows.length - 1]?.timestamp}`);
+  console.log(
+    `📅 Date range: ${allRows[0]?.timestamp} to ${allRows[allRows.length - 1]?.timestamp}`,
+  );
 
   // Show sample
   const sample = output.split('\n').slice(0, 4).join('\n');
@@ -84,7 +86,9 @@ function mergeCSVFiles(outputPath: string, pattern: string) {
 const args = process.argv.slice(2);
 if (args.length < 2) {
   console.error('Usage: pnpm tsx src/cli/merge-csv.ts <output-file> <pattern>');
-  console.error('Example: pnpm tsx src/cli/merge-csv.ts merged.csv "data/binance/btcusdt/1m/*-lona.csv"');
+  console.error(
+    'Example: pnpm tsx src/cli/merge-csv.ts merged.csv "data/binance/btcusdt/1m/*-lona.csv"',
+  );
   process.exit(1);
 }
 

--- a/src/cli/merge-week-5m-1h.ts
+++ b/src/cli/merge-week-5m-1h.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
 interface CandleRow {
   timestamp: string;
@@ -20,7 +20,7 @@ function mergeFiles(files: string[], outputPath: string) {
     }
     console.log(`  Reading: ${file}`);
     const content = readFileSync(file, 'utf-8');
-    const lines = content.split('\n').filter(line => line.trim());
+    const lines = content.split('\n').filter((line) => line.trim());
 
     if (!header && lines.length > 0) {
       header = lines[0];
@@ -36,7 +36,7 @@ function mergeFiles(files: string[], outputPath: string) {
   console.log(`✓ Total rows: ${allRows.length}`);
   allRows.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 
-  const output = header + '\n' + allRows.map(row => row.line).join('\n');
+  const output = `${header}\n${allRows.map((row) => row.line).join('\n')}`;
   writeFileSync(outputPath, output);
 
   console.log(`✅ Created: ${outputPath}`);

--- a/src/cli/merge-week.ts
+++ b/src/cli/merge-week.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 interface CandleRow {
   timestamp: string;
@@ -26,7 +26,7 @@ let header = '';
 for (const file of files) {
   console.log(`  Reading: ${file}`);
   const content = readFileSync(file, 'utf-8');
-  const lines = content.split('\n').filter(line => line.trim());
+  const lines = content.split('\n').filter((line) => line.trim());
 
   if (!header && lines.length > 0) {
     header = lines[0];
@@ -43,7 +43,7 @@ console.log(`✓ Total rows: ${allRows.length}`);
 console.log('🔄 Sorting by timestamp...');
 allRows.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 
-const output = header + '\n' + allRows.map(row => row.line).join('\n');
+const output = `${header}\n${allRows.map((row) => row.line).join('\n')}`;
 writeFileSync(outputPath, output);
 
 console.log(`\n✅ Merged file: ${outputPath}`);

--- a/src/components/charts/candlestick-chart.tsx
+++ b/src/components/charts/candlestick-chart.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
 import {
-  createChart,
-  ColorType,
-  IChartApi,
-  ISeriesApi,
-  CandlestickData,
-  CandlestickSeriesPartialOptions,
+  type CandlestickData,
   CandlestickSeries,
-  Time,
+  type CandlestickSeriesPartialOptions,
+  ColorType,
+  type IChartApi,
+  ISeriesApi,
+  type Time,
+  createChart,
 } from 'lightweight-charts';
+import { useEffect, useRef } from 'react';
 
 type CandleData = {
   time: number | string;

--- a/src/components/editors/code-editor.tsx
+++ b/src/components/editors/code-editor.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import Editor, { OnMount } from '@monaco-editor/react';
+import Editor, { type OnMount } from '@monaco-editor/react';
 import { useCallback, useRef } from 'react';
+
+type MonacoEditor = Parameters<OnMount>[0];
 
 interface CodeEditorProps {
   value: string;
@@ -20,7 +22,7 @@ export function CodeEditor({
   height = '400px',
   className,
 }: CodeEditorProps) {
-  const editorRef = useRef<any>(null);
+  const editorRef = useRef<MonacoEditor | null>(null);
 
   const handleEditorDidMount: OnMount = useCallback((editor) => {
     editorRef.current = editor;
@@ -32,7 +34,7 @@ export function CodeEditor({
         onChange(val);
       }
     },
-    [onChange]
+    [onChange],
   );
 
   return (

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -16,11 +16,25 @@ export function Logo({ className = '', variant = 'full', size = 'md' }: LogoProp
   if (variant === 'icon') {
     return (
       <div className={`${sizeClasses[size].icon} ${className}`}>
-        <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg
+          viewBox="0 0 32 32"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          role="img"
+          aria-label="Live Engine logo"
+        >
+          <title>Live Engine</title>
           <circle cx="16" cy="16" r="16" fill="url(#gradient)" />
           <path d="M18 4L10 16H16L14 28L22 16H16L18 4Z" fill="white" />
           <defs>
-            <linearGradient id="gradient" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+            <linearGradient
+              id="gradient"
+              x1="0"
+              y1="0"
+              x2="32"
+              y2="32"
+              gradientUnits="userSpaceOnUse"
+            >
               <stop offset="0%" stopColor="#3b82f6" />
               <stop offset="100%" stopColor="#8b5cf6" />
             </linearGradient>
@@ -33,11 +47,25 @@ export function Logo({ className = '', variant = 'full', size = 'md' }: LogoProp
   return (
     <div className={`flex items-center gap-2 ${className}`}>
       <div className={sizeClasses[size].icon}>
-        <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg
+          viewBox="0 0 32 32"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          role="img"
+          aria-label="Live Engine logo"
+        >
+          <title>Live Engine</title>
           <circle cx="16" cy="16" r="16" fill="url(#gradient)" />
           <path d="M18 4L10 16H16L14 28L22 16H16L18 4Z" fill="white" />
           <defs>
-            <linearGradient id="gradient" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+            <linearGradient
+              id="gradient"
+              x1="0"
+              y1="0"
+              x2="32"
+              y2="32"
+              gradientUnits="userSpaceOnUse"
+            >
               <stop offset="0%" stopColor="#3b82f6" />
               <stop offset="100%" stopColor="#8b5cf6" />
             </linearGradient>

--- a/src/components/marketing/lona-banner.tsx
+++ b/src/components/marketing/lona-banner.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import Link from 'next/link';
-import { X, Sparkles, Zap, TrendingUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Sparkles, TrendingUp, X, Zap } from 'lucide-react';
 import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 type LonaBannerProps = {
   variant?: 'compact' | 'full';
@@ -50,7 +50,10 @@ export function LonaBanner({ variant = 'full', dismissible = false }: LonaBanner
         <div className="relative flex items-center justify-between gap-4 p-4 backdrop-blur-sm">
           <div className="flex items-center gap-3">
             <div className="relative">
-              <Badge variant="default" className="bg-linear-to-r from-blue-600 to-purple-600 animate-pulse-glow">
+              <Badge
+                variant="default"
+                className="bg-linear-to-r from-blue-600 to-purple-600 animate-pulse-glow"
+              >
                 <Sparkles className="h-3 w-3 mr-1 inline animate-spin-slow" />
                 New
               </Badge>
@@ -58,7 +61,8 @@ export function LonaBanner({ variant = 'full', dismissible = false }: LonaBanner
 
             <p className="text-sm font-medium flex items-center gap-2">
               <Zap className="h-4 w-4 text-yellow-500 animate-bounce-subtle" />
-              Want the strategy for tomorrow&apos;s <span className="font-bold text-primary">100€ live challenge</span>?
+              Want the strategy for tomorrow&apos;s{' '}
+              <span className="font-bold text-primary">100€ live challenge</span>?
               <span className="hidden sm:inline">Generated in 15 seconds with plain English</span>
             </p>
           </div>
@@ -212,12 +216,24 @@ export function LonaBanner({ variant = 'full', dismissible = false }: LonaBanner
 
             <div className="flex flex-wrap items-center gap-4 text-sm">
               {[
-                { icon: <TrendingUp className="h-4 w-4" />, text: 'Backtesting included', delay: '0s' },
-                { icon: <Sparkles className="h-4 w-4" />, text: 'No credit card needed', delay: '0.2s' },
-                { icon: <Zap className="h-4 w-4" />, text: 'AI-generated strategies', delay: '0.4s' },
-              ].map((item, i) => (
+                {
+                  icon: <TrendingUp className="h-4 w-4" />,
+                  text: 'Backtesting included',
+                  delay: '0s',
+                },
+                {
+                  icon: <Sparkles className="h-4 w-4" />,
+                  text: 'No credit card needed',
+                  delay: '0.2s',
+                },
+                {
+                  icon: <Zap className="h-4 w-4" />,
+                  text: 'AI-generated strategies',
+                  delay: '0.4s',
+                },
+              ].map((item) => (
                 <div
-                  key={i}
+                  key={item.text}
                   className="flex items-center gap-2 animate-fade-in-up"
                   style={{ animationDelay: item.delay }}
                 >

--- a/src/components/providers/query-provider.tsx
+++ b/src/components/providers/query-provider.tsx
@@ -13,7 +13,7 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             refetchOnWindowFocus: false,
           },
         },
-      })
+      }),
   );
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/src/components/trading/live-ticker.tsx
+++ b/src/components/trading/live-ticker.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { MarketTickData } from '@/lib/stores/market-store';
+import { Card } from '@/components/ui/card';
+import type { MarketTickData } from '@/lib/stores/market-store';
 
 type LiveTickerProps = {
   asset: string;
@@ -23,7 +23,6 @@ type LiveTickerProps = {
  * ```
  */
 export function LiveTicker({ asset, tickData, isConnected }: LiveTickerProps) {
-
   const formatPrice = (price: number) => {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
@@ -36,7 +35,8 @@ export function LiveTicker({ asset, tickData, isConnected }: LiveTickerProps) {
   const formatVolume = (volume: number) => {
     if (volume >= 1_000_000) {
       return `${(volume / 1_000_000).toFixed(2)}M`;
-    } else if (volume >= 1_000) {
+    }
+    if (volume >= 1_000) {
       return `${(volume / 1_000).toFixed(2)}K`;
     }
     return volume.toFixed(2);
@@ -56,9 +56,7 @@ export function LiveTicker({ asset, tickData, isConnected }: LiveTickerProps) {
       {tickData ? (
         <>
           <div className="mb-4">
-            <div className="text-3xl font-bold text-foreground">
-              {formatPrice(tickData.price)}
-            </div>
+            <div className="text-3xl font-bold text-foreground">{formatPrice(tickData.price)}</div>
           </div>
 
           <div className="grid grid-cols-2 gap-4 text-sm">
@@ -68,9 +66,7 @@ export function LiveTicker({ asset, tickData, isConnected }: LiveTickerProps) {
             </div>
             <div>
               <div className="text-muted-foreground">Updated</div>
-              <div className="font-medium">
-                {new Date(tickData.timestamp).toLocaleTimeString()}
-              </div>
+              <div className="font-medium">{new Date(tickData.timestamp).toLocaleTimeString()}</div>
             </div>
           </div>
         </>

--- a/src/components/trading/order-form.tsx
+++ b/src/components/trading/order-form.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -13,6 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useState } from 'react';
 
 type OrderFormProps = {
   asset: string;
@@ -46,24 +46,24 @@ export function OrderForm({ asset, currentPrice, balance, onSubmit }: OrderFormP
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (side: 'buy' | 'sell') => {
-    if (!amount || parseFloat(amount) <= 0) {
+    if (!amount || Number.parseFloat(amount) <= 0) {
       alert('Please enter a valid amount');
       return;
     }
 
-    if (orderType === 'limit' && (!price || parseFloat(price) <= 0)) {
+    if (orderType === 'limit' && (!price || Number.parseFloat(price) <= 0)) {
       alert('Please enter a valid price for limit order');
       return;
     }
 
-    const orderAmount = parseFloat(amount);
-    const orderPrice = orderType === 'limit' ? parseFloat(price) : undefined;
+    const orderAmount = Number.parseFloat(amount);
+    const orderPrice = orderType === 'limit' ? Number.parseFloat(price) : undefined;
 
     const totalCost = orderPrice
       ? orderAmount * orderPrice
       : currentPrice
-      ? orderAmount * currentPrice
-      : 0;
+        ? orderAmount * currentPrice
+        : 0;
 
     if (side === 'buy' && totalCost > balance) {
       alert('Insufficient balance');
@@ -97,16 +97,16 @@ export function OrderForm({ asset, currentPrice, balance, onSubmit }: OrderFormP
   };
 
   const estimatedTotal = () => {
-    const amt = parseFloat(amount) || 0;
-    const prc = orderType === 'market'
-      ? currentPrice || 0
-      : parseFloat(price) || 0;
+    const amt = Number.parseFloat(amount) || 0;
+    const prc = orderType === 'market' ? currentPrice || 0 : Number.parseFloat(price) || 0;
     return amt * prc;
   };
 
   return (
     <Card className="p-4">
-      <h3 className="text-lg font-semibold mb-4">Place Order - {asset.toUpperCase().replace('USDT', '/USDT')}</h3>
+      <h3 className="text-lg font-semibold mb-4">
+        Place Order - {asset.toUpperCase().replace('USDT', '/USDT')}
+      </h3>
 
       <div className="space-y-4">
         <div className="grid grid-cols-2 gap-2">

--- a/src/components/trading/positions-card.tsx
+++ b/src/components/trading/positions-card.tsx
@@ -94,7 +94,8 @@ export function PositionsCard({ positions }: PositionsCardProps) {
                           {formatCurrency(position.unrealizedPnl)}
                         </div>
                         <div className="text-xs">
-                          ({isProfitable ? '+' : ''}{pnlPercent}%)
+                          ({isProfitable ? '+' : ''}
+                          {pnlPercent}%)
                         </div>
                       </div>
                     </TableCell>

--- a/src/components/trading/trades-table.tsx
+++ b/src/components/trading/trades-table.tsx
@@ -39,7 +39,8 @@ export function TradesTable({ asset, limit = 50 }: TradesTableProps) {
   const formatVolume = (volume: number) => {
     if (volume >= 1_000_000) {
       return `${(volume / 1_000_000).toFixed(2)}M`;
-    } else if (volume >= 1_000) {
+    }
+    if (volume >= 1_000) {
       return `${(volume / 1_000).toFixed(2)}K`;
     }
     return volume.toFixed(2);
@@ -86,15 +87,11 @@ export function TradesTable({ asset, limit = 50 }: TradesTableProps) {
             <TableBody>
               {trades.map((trade) => (
                 <TableRow key={trade.id}>
-                  <TableCell className="font-mono text-sm">
-                    {formatTime(trade.timestamp)}
-                  </TableCell>
+                  <TableCell className="font-mono text-sm">{formatTime(trade.timestamp)}</TableCell>
                   <TableCell className="font-medium uppercase">
                     {trade.asset.replace('usdt', '/USDT')}
                   </TableCell>
-                  <TableCell className="text-right font-mono">
-                    {formatPrice(trade.close)}
-                  </TableCell>
+                  <TableCell className="text-right font-mono">{formatPrice(trade.close)}</TableCell>
                   <TableCell className="text-right font-mono">
                     {formatVolume(trade.volume)}
                   </TableCell>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,36 +1,33 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps, cva } from 'class-variance-authority';
+import type * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
-        outline: "text-foreground",
+          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
-  }
-)
+  },
+);
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,57 +1,50 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from '@radix-ui/react-slot';
+import { type VariantProps, cva } from 'class-variance-authority';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : 'button';
     return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = "Button"
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  },
+);
+Button.displayName = 'Button';
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,76 +1,55 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
-      className
-    )}
-    {...props}
-  />
-))
-Card.displayName = "Card"
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-xl border bg-card text-card-foreground shadow', className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = 'Card';
 
-const CardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
-    {...props}
-  />
-))
-CardHeader.displayName = "CardHeader"
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  ),
+);
+CardHeader.displayName = 'CardHeader';
 
-const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
-    {...props}
-  />
-))
-CardTitle.displayName = "CardTitle"
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  ),
+);
+CardTitle.displayName = 'CardTitle';
 
-const CardDescription = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-CardDescription.displayName = "CardDescription"
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  ),
+);
+CardDescription.displayName = 'CardDescription';
 
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  ),
+);
+CardContent.displayName = 'CardContent';
 
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
-    {...props}
-  />
-))
-CardFooter.displayName = "CardFooter"
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  ),
+);
+CardFooter.displayName = 'CardFooter';
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,22 +1,22 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
   ({ className, type, ...props }, ref) => {
     return (
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          className
+          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className,
         )}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Input.displayName = "Input"
+    );
+  },
+);
+Input.displayName = 'Input';
 
-export { Input }
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,26 +1,21 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { type VariantProps, cva } from 'class-variance-authority';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+);
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label }
+export { Label };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,15 +1,15 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
-import { cn } from "@/lib/utils"
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons"
+import { cn } from '@/lib/utils';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from '@radix-ui/react-icons';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import * as React from 'react';
 
-const Select = SelectPrimitive.Root
+const Select = SelectPrimitive.Root;
 
-const SelectGroup = SelectPrimitive.Group
+const SelectGroup = SelectPrimitive.Group;
 
-const SelectValue = SelectPrimitive.Value
+const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
@@ -18,8 +18,8 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
-      className
+      'flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      className,
     )}
     {...props}
   >
@@ -28,8 +28,8 @@ const SelectTrigger = React.forwardRef<
       <ChevronDownIcon className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
@@ -37,16 +37,13 @@ const SelectScrollUpButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
-    className={cn(
-      "flex cursor-default items-center justify-center py-1",
-      className
-    )}
+    className={cn('flex cursor-default items-center justify-center py-1', className)}
     {...props}
   >
     <ChevronUpIcon className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
-))
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
@@ -54,30 +51,26 @@ const SelectScrollDownButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
-    className={cn(
-      "flex cursor-default items-center justify-center py-1",
-      className
-    )}
+    className={cn('flex cursor-default items-center justify-center py-1', className)}
     {...props}
   >
     <ChevronDownIcon className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
-))
-SelectScrollDownButton.displayName =
-  SelectPrimitive.ScrollDownButton.displayName
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
+>(({ className, children, position = 'popper', ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
-        position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-        className
+        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        className,
       )}
       position={position}
       {...props}
@@ -85,9 +78,9 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          "p-1",
-          position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
         )}
       >
         {children}
@@ -95,8 +88,8 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
@@ -104,11 +97,11 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    className={cn('px-2 py-1.5 text-sm font-semibold', className)}
     {...props}
   />
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
@@ -117,8 +110,8 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className,
     )}
     {...props}
   >
@@ -129,8 +122,8 @@ const SelectItem = React.forwardRef<
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
@@ -138,11 +131,11 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
     {...props}
   />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {
   Select,
@@ -155,4 +148,4 @@ export {
   SelectSeparator,
   SelectScrollUpButton,
   SelectScrollDownButton,
-}
+};

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,40 +1,31 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
-))
-Table.displayName = "Table"
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  ),
+);
+Table.displayName = 'Table';
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-))
-TableHeader.displayName = "TableHeader"
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
-))
-TableBody.displayName = "TableBody"
+  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+));
+TableBody.displayName = 'TableBody';
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
@@ -42,29 +33,25 @@ const TableFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tfoot
     ref={ref}
-    className={cn(
-      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
-    )}
+    className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
     {...props}
   />
-))
-TableFooter.displayName = "TableFooter"
+));
+TableFooter.displayName = 'TableFooter';
 
-const TableRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
-  <tr
-    ref={ref}
-    className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
-      className
-    )}
-    {...props}
-  />
-))
-TableRow.displayName = "TableRow"
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TableRow.displayName = 'TableRow';
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
@@ -73,13 +60,13 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
+      'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      className,
     )}
     {...props}
   />
-))
-TableHead.displayName = "TableHead"
+));
+TableHead.displayName = 'TableHead';
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
@@ -88,33 +75,20 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
+      'p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      className,
     )}
     {...props}
   />
-))
-TableCell.displayName = "TableCell"
+));
+TableCell.displayName = 'TableCell';
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
   React.HTMLAttributes<HTMLTableCaptionElement>
 >(({ className, ...props }, ref) => (
-  <caption
-    ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-TableCaption.displayName = "TableCaption"
+  <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+));
+TableCaption.displayName = 'TableCaption';
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-}
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,11 +1,11 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Tabs = TabsPrimitive.Root
+const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -14,13 +14,13 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
-      className
+      'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+      className,
     )}
     {...props}
   />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
@@ -29,13 +29,13 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
-      className
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+      className,
     )}
     {...props}
   />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -44,12 +44,12 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className,
     )}
     {...props}
   />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/lib/ai-config.ts
+++ b/src/lib/ai-config.ts
@@ -11,10 +11,10 @@
  *   AI_MODEL_EXPLANATION - Override explanation model
  */
 
-import { xai } from '@ai-sdk/xai';
-import { openai } from '@ai-sdk/openai';
 import { anthropic } from '@ai-sdk/anthropic';
 import { google } from '@ai-sdk/google';
+import { openai } from '@ai-sdk/openai';
+import { xai } from '@ai-sdk/xai';
 import type { LanguageModel } from 'ai';
 
 // Supported providers

--- a/src/lib/ai-convert.ts
+++ b/src/lib/ai-convert.ts
@@ -1,6 +1,6 @@
-import { z } from 'zod';
-import { wrapAISDK } from 'langsmith/experimental/vercel';
 import * as ai from 'ai';
+import { wrapAISDK } from 'langsmith/experimental/vercel';
+import { z } from 'zod';
 import { getModelForTask } from './ai-config';
 
 // Wrap AI SDK with LangSmith observability
@@ -27,7 +27,7 @@ export type ConversionResult = z.infer<typeof conversionSchema>;
  */
 export async function convertPythonToTypescript(
   pythonCode: string,
-  context?: string
+  context?: string,
 ): Promise<ConversionResult> {
   const { model, temperature, provider, modelId } = getModelForTask('conversion');
   console.log(`[AI Convert] Using ${provider}:${modelId} for conversion`);
@@ -93,7 +93,9 @@ Provide a complete TypeScript implementation that:
     return result;
   } catch (error) {
     console.error('Error converting Python to TypeScript:', error);
-    throw new Error(`Failed to convert code: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(
+      `Failed to convert code: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
 
@@ -151,7 +153,8 @@ export async function explainStrategy(pythonCode: string): Promise<string> {
 
   const { text } = await wrappedGenerateText({
     model,
-    system: `You are a trading strategy analyst. Explain trading code in clear, simple language that a non-programmer can understand.`,
+    system:
+      'You are a trading strategy analyst. Explain trading code in clear, simple language that a non-programmer can understand.',
     prompt: `Explain this trading strategy in 2-3 paragraphs:\n\n\`\`\`python\n${pythonCode}\n\`\`\`\n\nInclude:
 - What the strategy does
 - When it buys/sells

--- a/src/lib/broker.ts
+++ b/src/lib/broker.ts
@@ -41,7 +41,7 @@ class BrokerClient {
       apiKey?: string;
       apiSecret?: string;
       testnet?: boolean;
-    }
+    },
   ) {
     this.exchange = this.initializeExchange();
   }
@@ -108,19 +108,15 @@ class BrokerClient {
     try {
       await this.exchange.loadMarkets();
 
-      let order;
+      let order: ccxt.Order;
       if (params.type === 'market') {
-        order = await this.exchange.createMarketOrder(
-          params.symbol,
-          params.side,
-          params.amount
-        );
+        order = await this.exchange.createMarketOrder(params.symbol, params.side, params.amount);
       } else if (params.type === 'limit' && params.price) {
         order = await this.exchange.createLimitOrder(
           params.symbol,
           params.side,
           params.amount,
-          params.price
+          params.price,
         );
       } else {
         throw new Error('Invalid order type or missing price for limit order');
@@ -143,7 +139,7 @@ class BrokerClient {
 
       // Return only non-zero balances
       return Object.fromEntries(
-        Object.entries(free).filter(([_, amount]) => (amount as number) > 0)
+        Object.entries(free).filter(([_, amount]) => (amount as number) > 0),
       ) as Record<string, number>;
     } catch (error) {
       console.error('Error fetching balance:', error);
@@ -157,7 +153,7 @@ class BrokerClient {
   async getOpenOrders(symbol?: string): Promise<OrderResult[]> {
     try {
       const orders = await this.exchange.fetchOpenOrders(symbol);
-      return orders.map((order: any) => this.formatOrder(order));
+      return orders.map((order) => this.formatOrder(order));
     } catch (error) {
       console.error('Error fetching open orders:', error);
       throw error;
@@ -212,7 +208,7 @@ class BrokerClient {
       type: order.type as OrderType,
       amount: order.amount,
       price: order.price || 0,
-      status: order.status as any,
+      status: (order.status || 'pending') as OrderResult['status'],
       timestamp: order.timestamp || Date.now(),
       fee: order.fee
         ? {
@@ -233,7 +229,7 @@ export function createBrokerClient(
     apiKey?: string;
     apiSecret?: string;
     testnet?: boolean;
-  } = {}
+  } = {},
 ): BrokerClient {
   return new BrokerClient(broker, options);
 }
@@ -241,9 +237,10 @@ export function createBrokerClient(
 /**
  * Get default broker credentials from environment
  */
-export function getDefaultBrokerCredentials(
-  broker: BrokerName
-): { apiKey: string; apiSecret: string } {
+export function getDefaultBrokerCredentials(broker: BrokerName): {
+  apiKey: string;
+  apiSecret: string;
+} {
   switch (broker) {
     case 'binance':
       return {

--- a/src/lib/hooks/use-strategies.ts
+++ b/src/lib/hooks/use-strategies.ts
@@ -1,10 +1,10 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type {
+  CreateStrategyInput,
   Strategy,
   StrategyLog,
-  CreateStrategyInput,
   UpdateStrategyInput,
 } from '@/lib/types/strategy';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 const STRATEGIES_KEY = ['strategies'];
 
@@ -43,7 +43,7 @@ export function useStrategy(id: string | undefined) {
  */
 export function useStrategyLogs(
   strategyId: string | undefined,
-  options?: { limit?: number; level?: string; refetchInterval?: number }
+  options?: { limit?: number; level?: string; refetchInterval?: number },
 ) {
   return useQuery<{ logs: StrategyLog[]; total: number }>({
     queryKey: [...STRATEGIES_KEY, strategyId, 'logs', options?.level],

--- a/src/lib/langsmith.ts
+++ b/src/lib/langsmith.ts
@@ -29,8 +29,8 @@ export function createTraceable<TInput, TOutput>(
   fn: (input: TInput) => Promise<TOutput>,
   options?: {
     tags?: string[];
-    metadata?: Record<string, any>;
-  }
+    metadata?: Record<string, unknown>;
+  },
 ) {
   return traceable(fn, {
     name,
@@ -45,7 +45,7 @@ export function createTraceable<TInput, TOutput>(
  */
 export const tracedConversion = createTraceable<
   { pythonCode: string; context?: string },
-  any
+  { pythonCode: string; context?: string }
 >('python-to-typescript', async ({ pythonCode, context }) => {
   // This will be called from ai-convert.ts
   // LangSmith will automatically capture the trace

--- a/src/lib/python-executor.ts
+++ b/src/lib/python-executor.ts
@@ -13,7 +13,7 @@
 
 export interface PythonExecutionResult {
   success: boolean;
-  output?: any;
+  output?: unknown;
   error?: string;
   executionTime?: number;
   recommendation: string;
@@ -30,11 +30,9 @@ export interface PythonExecutionResult {
  */
 export async function executePythonCode(
   code: string,
-  inputs?: Record<string, any>
+  inputs?: Record<string, unknown>,
 ): Promise<PythonExecutionResult> {
-  console.warn(
-    'Python executor called - this is a placeholder implementation'
-  );
+  console.warn('Python executor called - this is a placeholder implementation');
 
   // For security and performance, we recommend converting Python → TypeScript
   // using the /api/convert endpoint (Grok AI) instead of executing Python directly
@@ -62,8 +60,7 @@ export function validatePythonSyntax(code: string): {
   }
 
   // Check for common Python keywords
-  const hasValidKeywords =
-    /def |class |import |from |if |for |while /.test(code);
+  const hasValidKeywords = /def |class |import |from |if |for |while /.test(code);
 
   if (!hasValidKeywords && code.length > 10) {
     errors.push('Code does not appear to be valid Python');

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -2,8 +2,8 @@ import { Redis } from '@upstash/redis';
 
 // Initialize Upstash Redis client
 export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL!,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+  url: process.env.UPSTASH_REDIS_REST_URL ?? '',
+  token: process.env.UPSTASH_REDIS_REST_TOKEN ?? '',
 });
 
 /**
@@ -16,8 +16,7 @@ export const redis = new Redis({
 
 export const cacheKeys = {
   marketLatest: (asset: string) => `market:${asset}:latest`,
-  market1m: (asset: string, timestamp: number) =>
-    `market:${asset}:1m:${timestamp}`,
+  market1m: (asset: string, timestamp: number) => `market:${asset}:1m:${timestamp}`,
   tradeQueue: 'queue:trades',
   dataQueue: 'queue:data',
   userSession: (userId: string) => `session:${userId}`,
@@ -28,7 +27,7 @@ export const cacheKeys = {
  */
 export async function cacheMarketTick(
   asset: string,
-  data: { price: number; volume: number; timestamp: number }
+  data: { price: number; volume: number; timestamp: number },
 ) {
   const key = cacheKeys.marketLatest(asset);
   await redis.set(key, JSON.stringify(data), { ex: 60 }); // 1 min TTL

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
 
 // Client for browser-side operations (respects RLS)
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": [
@@ -35,8 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "examples"
-  ]
+  "exclude": ["node_modules", "examples"]
 }


### PR DESCRIPTION
## Summary

- Replace ESLint + eslint-config-next with Biome (single dependency, ~100x faster)
- Replace `any` types with proper types across 12 files
- Replace array index keys with stable keys in 5 components
- Add SVG accessibility (title + role) to logo component
- Add `docs/binance-data-retrieval.md` and `scripts/download-btc-data.ts`
- Gitignore generated data files (*.csv, *_report*.txt, *_trades*.txt)

## Test plan

- [x] `biome check .` — 0 errors, 74 files, 28ms
- [x] `tsc --noEmit` — 0 errors
- [x] `pnpm build` — all 18 routes compiled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly developer-tooling and documentation changes; the only code changes are small type/format adjustments in example strategy files.
> 
> **Overview**
> **Tooling migration:** Removes ESLint (`eslint.config.mjs`, `eslint`/`eslint-config-next` deps) and switches `package.json` scripts/docs to Biome (`lint`, `lint:fix`, `format`) with a new `biome.json` config.
> 
> **Repo hygiene & docs:** Expands `.gitignore` to exclude generated market data outputs (`*.csv`, `*_report*.txt`, `*_trades*.txt`) and adds a large `docs/binance-data-retrieval.md` guide for downloading/streaming/caching Binance market data.
> 
> **TypeScript cleanup:** Adjusts `examples/lona-strategy.ts` and `examples/sample-strategy.ts` for type-only `ccxt` imports, safer `NaN`/null handling, and minor formatting/typing tightening to satisfy the new linter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49954848e17607b24eba3e759ab4ab6c54e41711. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->