### PR TITLE
Fix strategy execution parse failures from generated TS code

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tailwind-merge": "^3.4.0",
+    "typescript": "^5.9.3",
     "tsx": "^4.21.0",
     "ws": "^8.19.0",
     "zod": "^4.3.6",
@@ -56,7 +57,6 @@
     "@types/ws": "^8.18.1",
     "autoprefixer": "^10.4.24",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3"
+    "tailwindcss": "^4.1.18"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -132,9 +135,6 @@ importers:
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
 
 packages:
 

--- a/src/lib/ai-convert.ts
+++ b/src/lib/ai-convert.ts
@@ -10,7 +10,7 @@ const { generateText: wrappedGenerateText, generateObject: wrappedGenerateObject
  * Schema for structured Python → TypeScript conversion
  */
 const conversionSchema = z.object({
-  typescript_code: z.string().describe('Converted TypeScript code'),
+  typescript_code: z.string().describe('Converted runtime-safe JavaScript code'),
   dependencies: z.array(z.string()).describe('Required npm packages'),
   notes: z.string().describe('Conversion notes and recommendations'),
   original_intent: z.string().describe('Summary of what the Python code does'),

--- a/src/lib/ai-convert.ts
+++ b/src/lib/ai-convert.ts
@@ -36,7 +36,7 @@ export async function convertPythonToTypescript(
 
 Your task is to convert Python trading code to TypeScript that works with:
 - ccxt library for broker execution (Binance, Bybit, IBKR, etc.)
-- Type-safe interfaces and proper error handling
+- Plain JavaScript runtime semantics and proper error handling
 - Modern async/await patterns
 - Clean, production-ready code
 
@@ -45,9 +45,11 @@ The generated code runs inside a Function constructor (new Function()), NOT as a
 You MUST follow these rules:
 - Do NOT use import or export statements (they cause "Cannot use import statement outside a module")
 - Do NOT use "require()" calls
-- Define all helper functions, interfaces, and types inline
+- Do NOT use TypeScript-only syntax (no interfaces, type aliases, enums, generics, type annotations, or "as" assertions)
+- Output plain JavaScript that is valid in Node.js Function() execution
 - Implement indicator calculations (SMA, RSI, EMA, MACD, Bollinger Bands, etc.) as plain functions using Math and Array methods
 - The main entry point MUST be a function named "tradingStrategy" that takes a single "context" parameter and returns a result object
+- Do NOT reference external type names like Exchange, Order, Position, or Candle
 
 The context parameter has this shape:
 {
@@ -78,11 +80,10 @@ Backtrader to TypeScript mappings:
 
 Additional requirements:
 - Preserve the original trading logic exactly
-- Use TypeScript best practices (strict types, interfaces)
+- Keep the output JavaScript-only while preserving TypeScript-compatible structure
 - Convert pandas operations to native JavaScript/TypeScript
 - Convert numpy to native math operations
 - Include comprehensive error handling
-- Add type definitions for all functions and variables
 - ALL code must be self-contained with zero external dependencies`;
 
   const userPrompt = `Convert this Python trading code to TypeScript:
@@ -141,6 +142,7 @@ export async function validateTypescriptCode(typescriptCode: string): Promise<{
 - Trading logic bugs
 - Performance problems
 - Security vulnerabilities
+- Function-constructor compatibility (no import/export/require, runnable without module context)
 
 Respond with a JSON object containing:
 - isValid: boolean

--- a/src/lib/ai-convert.ts
+++ b/src/lib/ai-convert.ts
@@ -86,7 +86,7 @@ Additional requirements:
 - Include comprehensive error handling
 - ALL code must be self-contained with zero external dependencies`;
 
-  const userPrompt = `Convert this Python trading code to TypeScript:
+  const userPrompt = `Convert this Python trading code to runtime-safe JavaScript:
 
 \`\`\`python
 ${pythonCode}
@@ -94,7 +94,7 @@ ${pythonCode}
 
 ${context ? `\n**Strategy Context:**\n${context}` : ''}
 
-Provide a complete TypeScript implementation that:
+Provide a complete JavaScript implementation that:
 1. Maintains the exact same trading logic
 2. Is completely self-contained (NO import/export/require statements)
 3. Defines a "tradingStrategy(context)" function as the entry point

--- a/src/lib/ai-convert.ts
+++ b/src/lib/ai-convert.ts
@@ -34,7 +34,7 @@ export async function convertPythonToTypescript(
 
   const systemPrompt = `You are an expert Python and TypeScript developer specializing in algorithmic trading systems.
 
-Your task is to convert Python trading code to TypeScript that works with:
+Your task is to convert Python trading code to runtime-safe JavaScript that works with:
 - ccxt library for broker execution (Binance, Bybit, IBKR, etc.)
 - Plain JavaScript runtime semantics and proper error handling
 - Modern async/await patterns

--- a/src/lib/strategy/executor.ts
+++ b/src/lib/strategy/executor.ts
@@ -97,9 +97,9 @@ export async function executeStrategy(
   context: StrategyContext,
 ): Promise<StrategyResult> {
   try {
-    // Strip import/export statements that can't run in Function constructor
-    const cleanCode = sanitizeForExecution(typescriptCode);
-    const executableCode = await transpileForExecution(cleanCode);
+    // Transpile first, then strip any module syntax injected by transpilation.
+    const transpiledCode = await transpileForExecution(typescriptCode);
+    const executableCode = sanitizeForExecution(transpiledCode);
 
     // Create a sandboxed function with the strategy code
     const wrappedCode = `

--- a/src/lib/strategy/executor.ts
+++ b/src/lib/strategy/executor.ts
@@ -20,6 +20,7 @@ async function loadTypeScriptModule(): Promise<TypeScriptModule> {
     typeScriptModulePromise = import('typescript')
       .then((mod) => mod.default ?? mod)
       .catch((error) => {
+        typeScriptModulePromise = null;
         const detail = error instanceof Error ? error.message : String(error);
         throw new Error(
           `TypeScript runtime dependency is required for strategy transpilation. Ensure "typescript" is installed in production dependencies. Original error: ${detail}`,
@@ -83,6 +84,7 @@ function sanitizeForExecution(code: string): string {
       if (trimmed.startsWith('export class ')) return line.replace('export class ', 'class ');
       if (trimmed.startsWith('export const ')) return line.replace('export const ', 'const ');
       if (trimmed.startsWith('export let ')) return line.replace('export let ', 'let ');
+      if (trimmed.startsWith('export var ')) return line.replace('export var ', 'var ');
       // Remove "export default" prefix
       if (trimmed.startsWith('export default ')) return line.replace('export default ', '');
       // Remove bare "export { ... }" re-exports


### PR DESCRIPTION
Summary:\n- transpile generated strategy code to executable JavaScript before runtime execution\n- keep import export sanitization and compile away TypeScript-only syntax that caused parse failures\n- harden conversion prompt to require function-compatible output and avoid external type identifiers such as Exchange\n- extend validation guidance to check function-constructor compatibility\n\nTesting:\n- pnpm typecheck\n\nCloses #10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Strategy execution now depends on runtime TypeScript transpilation; misconfiguration (missing `typescript` in prod) or transpile differences could break live strategy runs, but changes are localized and include explicit error handling.
> 
> **Overview**
> Fixes runtime parse failures when executing AI-generated strategy code by **transpiling TypeScript to plain JavaScript** before evaluating it in `new Function()`.
> 
> `executeStrategy` now lazy-loads the `typescript` runtime dependency, transpiles with `transpileModule` (failing fast on TS diagnostics), and then sanitizes remaining module syntax (including `export var`). The AI conversion/validation prompts are tightened to request Function-constructor-safe JavaScript output and to avoid TypeScript-only syntax and external type identifiers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c64d31cd3d6717dc07e8fd9528bfa988f942a891. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->