### PR TITLE
[E-03] Align live-engine internal execution routes to adapter contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:fix": "biome check --fix .",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/lib/internal/*.test.ts",
     "cli": "tsx src/cli/index.ts"
   },
   "dependencies": {

--- a/src/app/api/internal/deployments/[deploymentId]/route.ts
+++ b/src/app/api/internal/deployments/[deploymentId]/route.ts
@@ -1,0 +1,25 @@
+import { getDeployment } from '@/lib/internal/execution-store';
+import { getAuthUserId } from '@/lib/service-auth';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ deploymentId: string }> },
+) {
+  try {
+    await getAuthUserId(request);
+    const params = await context.params;
+    const deployment = getDeployment(params.deploymentId);
+    if (!deployment) {
+      return NextResponse.json({ error: 'Deployment not found' }, { status: 404 });
+    }
+    return NextResponse.json({ deployment });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to fetch deployment' }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/deployments/[deploymentId]/stop/route.ts
+++ b/src/app/api/internal/deployments/[deploymentId]/stop/route.ts
@@ -1,0 +1,25 @@
+import { getAuthUserId } from '@/lib/service-auth';
+import { stopDeployment } from '@/lib/internal/execution-store';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ deploymentId: string }> },
+) {
+  try {
+    await getAuthUserId(request);
+    const params = await context.params;
+    const deployment = stopDeployment(params.deploymentId);
+    if (!deployment) {
+      return NextResponse.json({ error: 'Deployment not found' }, { status: 404 });
+    }
+    return NextResponse.json({ deployment });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to stop deployment' }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/deployments/route.ts
+++ b/src/app/api/internal/deployments/route.ts
@@ -1,0 +1,48 @@
+import { getAuthUserId } from '@/lib/service-auth';
+import { createDeployment, listDeployments } from '@/lib/internal/execution-store';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+interface CreateDeploymentRequest {
+  strategyId: string;
+  mode: 'paper' | 'live';
+  capital: number;
+  idempotencyKey?: string;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    await getAuthUserId(request);
+    const status = new URL(request.url).searchParams.get('status');
+    return NextResponse.json({
+      items: listDeployments(status),
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to list deployments' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await getAuthUserId(request);
+    const body = (await request.json()) as CreateDeploymentRequest;
+    if (!body.strategyId || !body.mode || typeof body.capital !== 'number') {
+      return NextResponse.json({ error: 'Missing required deployment fields' }, { status: 400 });
+    }
+    const deployment = createDeployment({
+      strategyId: body.strategyId,
+      mode: body.mode,
+      capital: body.capital,
+    });
+    return NextResponse.json({ deployment }, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to create deployment' }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/orders/[orderId]/route.ts
+++ b/src/app/api/internal/orders/[orderId]/route.ts
@@ -1,0 +1,45 @@
+import { cancelOrder, getOrder } from '@/lib/internal/execution-store';
+import { getAuthUserId } from '@/lib/service-auth';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ orderId: string }> },
+) {
+  try {
+    await getAuthUserId(request);
+    const params = await context.params;
+    const order = getOrder(params.orderId);
+    if (!order) {
+      return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+    }
+    return NextResponse.json({ order });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to fetch order' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ orderId: string }> },
+) {
+  try {
+    await getAuthUserId(request);
+    const params = await context.params;
+    const order = cancelOrder(params.orderId);
+    if (!order) {
+      return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+    }
+    return NextResponse.json({ order });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to cancel order' }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/orders/route.ts
+++ b/src/app/api/internal/orders/route.ts
@@ -1,0 +1,55 @@
+import { getAuthUserId } from '@/lib/service-auth';
+import { listOrders, placeOrder } from '@/lib/internal/execution-store';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+interface PlaceOrderRequest {
+  symbol: string;
+  side: 'buy' | 'sell';
+  type: 'market' | 'limit';
+  quantity: number;
+  price?: number | null;
+  deploymentId?: string | null;
+  idempotencyKey?: string;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    await getAuthUserId(request);
+    const status = new URL(request.url).searchParams.get('status');
+    return NextResponse.json({ items: listOrders(status) });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to list orders' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await getAuthUserId(request);
+    const body = (await request.json()) as PlaceOrderRequest;
+    if (!body.symbol || !body.side || !body.type || typeof body.quantity !== 'number') {
+      return NextResponse.json({ error: 'Missing required order fields' }, { status: 400 });
+    }
+    if (body.type === 'limit' && typeof body.price !== 'number') {
+      return NextResponse.json({ error: 'Limit order requires price' }, { status: 400 });
+    }
+    const order = placeOrder({
+      symbol: body.symbol,
+      side: body.side,
+      type: body.type,
+      quantity: body.quantity,
+      price: body.price ?? null,
+      deploymentId: body.deploymentId ?? null,
+    });
+    return NextResponse.json({ order }, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to place order' }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/orders/route.ts
+++ b/src/app/api/internal/orders/route.ts
@@ -34,7 +34,9 @@ export async function POST(request: NextRequest) {
     if (!body.symbol || !body.side || !body.type || typeof body.quantity !== 'number') {
       return NextResponse.json({ error: 'Missing required order fields' }, { status: 400 });
     }
-    if (body.type === 'limit' && typeof body.price !== 'number') {
+    const hasValidLimitPrice =
+      body.price !== null && body.price !== undefined && typeof body.price === 'number' && Number.isFinite(body.price) && body.price > 0;
+    if (body.type === 'limit' && !hasValidLimitPrice) {
       return NextResponse.json({ error: 'Limit order requires price' }, { status: 400 });
     }
     const order = placeOrder({

--- a/src/app/api/internal/portfolios/[portfolioId]/route.ts
+++ b/src/app/api/internal/portfolios/[portfolioId]/route.ts
@@ -1,0 +1,25 @@
+import { getPortfolio } from '@/lib/internal/execution-store';
+import { getAuthUserId } from '@/lib/service-auth';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ portfolioId: string }> },
+) {
+  try {
+    await getAuthUserId(request);
+    const params = await context.params;
+    const portfolio = getPortfolio(params.portfolioId);
+    if (!portfolio) {
+      return NextResponse.json({ error: 'Portfolio not found' }, { status: 404 });
+    }
+    return NextResponse.json({ portfolio });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to fetch portfolio' }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/portfolios/route.ts
+++ b/src/app/api/internal/portfolios/route.ts
@@ -1,0 +1,17 @@
+import { listPortfolios } from '@/lib/internal/execution-store';
+import { getAuthUserId } from '@/lib/service-auth';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest) {
+  try {
+    await getAuthUserId(request);
+    return NextResponse.json({ items: listPortfolios() });
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to list portfolios' }, { status: 500 });
+  }
+}

--- a/src/lib/internal/execution-store.test.ts
+++ b/src/lib/internal/execution-store.test.ts
@@ -6,6 +6,7 @@ import {
   createDeployment,
   getDeployment,
   getOrder,
+  mapCancelTransition,
   placeOrder,
   resetExecutionStore,
   stopDeployment,
@@ -40,6 +41,7 @@ test('order lifecycle supports provider-id lookup and cancellation', () => {
     deploymentId: null,
   });
   assert.equal(order.status, 'pending');
+  assert.equal(order.providerOrderId, 'live-order-002');
 
   const fetched = getOrder(order.providerOrderId);
   assert.ok(fetched);
@@ -48,4 +50,12 @@ test('order lifecycle supports provider-id lookup and cancellation', () => {
   const cancelled = cancelOrder(order.providerOrderId);
   assert.ok(cancelled);
   assert.equal(cancelled.status, 'cancelled');
+});
+
+test('cancel transition preserves terminal order states', () => {
+  assert.equal(mapCancelTransition('pending'), 'cancelled');
+  assert.equal(mapCancelTransition('filled'), 'filled');
+  assert.equal(mapCancelTransition('cancelled'), 'cancelled');
+  assert.equal(mapCancelTransition('rejected'), 'rejected');
+  assert.equal(mapCancelTransition('failed'), 'failed');
 });

--- a/src/lib/internal/execution-store.test.ts
+++ b/src/lib/internal/execution-store.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  cancelOrder,
+  createDeployment,
+  getDeployment,
+  getOrder,
+  placeOrder,
+  resetExecutionStore,
+  stopDeployment,
+} from '@/lib/internal/execution-store';
+
+test('deployment lifecycle transitions map to adapter semantics', () => {
+  resetExecutionStore();
+  const deployment = createDeployment({
+    strategyId: 'strat-abc',
+    mode: 'paper',
+    capital: 10000,
+  });
+  assert.equal(deployment.status, 'queued');
+
+  const fetchedByProviderRef = getDeployment(deployment.providerRefId);
+  assert.ok(fetchedByProviderRef);
+  assert.equal(fetchedByProviderRef.id, deployment.id);
+
+  const stopped = stopDeployment(deployment.providerRefId);
+  assert.ok(stopped);
+  assert.equal(stopped.status, 'stopping');
+});
+
+test('order lifecycle supports provider-id lookup and cancellation', () => {
+  resetExecutionStore();
+  const order = placeOrder({
+    symbol: 'BTCUSDT',
+    side: 'buy',
+    type: 'market',
+    quantity: 0.2,
+    price: null,
+    deploymentId: null,
+  });
+  assert.equal(order.status, 'pending');
+
+  const fetched = getOrder(order.providerOrderId);
+  assert.ok(fetched);
+  assert.equal(fetched.id, order.id);
+
+  const cancelled = cancelOrder(order.providerOrderId);
+  assert.ok(cancelled);
+  assert.equal(cancelled.status, 'cancelled');
+});

--- a/src/lib/internal/execution-store.ts
+++ b/src/lib/internal/execution-store.ts
@@ -100,6 +100,10 @@ function nextOrderId(): string {
   return id;
 }
 
+function nextProviderOrderId(orderId: string): string {
+  return `live-order-${orderId.replace(/^ord-/, '')}`;
+}
+
 function findDeployment(identifier: string): DeploymentContract | undefined {
   const direct = deployments.get(identifier);
   if (direct) {
@@ -176,7 +180,7 @@ export function placeOrder(input: PlaceOrderInput): OrderContract {
   const id = nextOrderId();
   const order: OrderContract = {
     id,
-    providerOrderId: `live-order-${id}`,
+    providerOrderId: nextProviderOrderId(id),
     symbol: input.symbol,
     side: input.side,
     type: input.type,
@@ -210,12 +214,9 @@ export function cancelOrder(identifier: string): OrderContract | null {
   return cloneContract(order);
 }
 
-function mapCancelTransition(current: OrderStatus): OrderStatus {
-  if (current === 'filled') {
-    return 'filled';
-  }
-  if (current === 'cancelled') {
-    return 'cancelled';
+export function mapCancelTransition(current: OrderStatus): OrderStatus {
+  if (current === 'filled' || current === 'cancelled' || current === 'rejected' || current === 'failed') {
+    return current;
   }
   return 'cancelled';
 }

--- a/src/lib/internal/execution-store.ts
+++ b/src/lib/internal/execution-store.ts
@@ -1,0 +1,234 @@
+import type {
+  DeploymentContract,
+  DeploymentStatus,
+  OrderContract,
+  OrderStatus,
+  PortfolioContract,
+} from '@/lib/types/execution-contract';
+
+interface CreateDeploymentInput {
+  strategyId: string;
+  mode: 'paper' | 'live';
+  capital: number;
+}
+
+interface PlaceOrderInput {
+  symbol: string;
+  side: 'buy' | 'sell';
+  type: 'market' | 'limit';
+  quantity: number;
+  price: number | null;
+  deploymentId: string | null;
+}
+
+function nowIso(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function cloneContract<T>(value: T): T {
+  return structuredClone(value);
+}
+
+let deploymentCounter = 2;
+let orderCounter = 2;
+
+const deployments = new Map<string, DeploymentContract>();
+const orders = new Map<string, OrderContract>();
+const portfolios = new Map<string, PortfolioContract>();
+
+function seedStore(): void {
+  deployments.clear();
+  orders.clear();
+  portfolios.clear();
+  deploymentCounter = 2;
+  orderCounter = 2;
+
+  deployments.set('dep-001', {
+    id: 'dep-001',
+    strategyId: 'strat-001',
+    mode: 'paper',
+    status: 'running',
+    capital: 20000,
+    providerRefId: 'live-dep-001',
+    latestPnl: 120.25,
+    createdAt: '2026-02-13T20:00:00Z',
+    updatedAt: '2026-02-14T10:00:00Z',
+  });
+
+  orders.set('ord-001', {
+    id: 'ord-001',
+    providerOrderId: 'live-order-001',
+    symbol: 'BTCUSDT',
+    side: 'buy',
+    type: 'limit',
+    quantity: 0.1,
+    price: 64800,
+    status: 'pending',
+    deploymentId: 'dep-001',
+    createdAt: '2026-02-14T10:02:00Z',
+  });
+
+  portfolios.set('portfolio-paper-001', {
+    id: 'portfolio-paper-001',
+    mode: 'paper',
+    cash: 12450.75,
+    totalValue: 20891.12,
+    pnlTotal: 891.12,
+    positions: [
+      {
+        symbol: 'BTCUSDT',
+        quantity: 0.3,
+        avgPrice: 62000,
+        currentPrice: 64800,
+        unrealizedPnl: 840,
+      },
+    ],
+  });
+}
+
+seedStore();
+
+function nextDeploymentId(): string {
+  const id = `dep-${String(deploymentCounter).padStart(3, '0')}`;
+  deploymentCounter += 1;
+  return id;
+}
+
+function nextOrderId(): string {
+  const id = `ord-${String(orderCounter).padStart(3, '0')}`;
+  orderCounter += 1;
+  return id;
+}
+
+function findDeployment(identifier: string): DeploymentContract | undefined {
+  const direct = deployments.get(identifier);
+  if (direct) {
+    return direct;
+  }
+  for (const deployment of deployments.values()) {
+    if (deployment.providerRefId === identifier) {
+      return deployment;
+    }
+  }
+  return undefined;
+}
+
+function findOrder(identifier: string): OrderContract | undefined {
+  const direct = orders.get(identifier);
+  if (direct) {
+    return direct;
+  }
+  for (const order of orders.values()) {
+    if (order.providerOrderId === identifier) {
+      return order;
+    }
+  }
+  return undefined;
+}
+
+export function createDeployment(input: CreateDeploymentInput): DeploymentContract {
+  const id = nextDeploymentId();
+  const now = nowIso();
+  const deployment: DeploymentContract = {
+    id,
+    strategyId: input.strategyId,
+    mode: input.mode,
+    status: 'queued',
+    capital: input.capital,
+    providerRefId: `live-${id}`,
+    latestPnl: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  deployments.set(id, deployment);
+  return cloneContract(deployment);
+}
+
+export function listDeployments(status?: string | null): DeploymentContract[] {
+  const items = Array.from(deployments.values());
+  const filtered = status ? items.filter((item) => item.status === status) : items;
+  return filtered.map((item) => cloneContract(item));
+}
+
+export function getDeployment(identifier: string): DeploymentContract | null {
+  const deployment = findDeployment(identifier);
+  return deployment ? cloneContract(deployment) : null;
+}
+
+export function stopDeployment(identifier: string): DeploymentContract | null {
+  const deployment = findDeployment(identifier);
+  if (!deployment) {
+    return null;
+  }
+  deployment.status = mapStopTransition(deployment.status);
+  deployment.updatedAt = nowIso();
+  return cloneContract(deployment);
+}
+
+function mapStopTransition(current: DeploymentStatus): DeploymentStatus {
+  if (current === 'stopped' || current === 'failed') {
+    return current;
+  }
+  return 'stopping';
+}
+
+export function placeOrder(input: PlaceOrderInput): OrderContract {
+  const id = nextOrderId();
+  const order: OrderContract = {
+    id,
+    providerOrderId: `live-order-${id}`,
+    symbol: input.symbol,
+    side: input.side,
+    type: input.type,
+    quantity: input.quantity,
+    price: input.price,
+    status: 'pending',
+    deploymentId: input.deploymentId,
+    createdAt: nowIso(),
+  };
+  orders.set(id, order);
+  return cloneContract(order);
+}
+
+export function listOrders(status?: string | null): OrderContract[] {
+  const items = Array.from(orders.values());
+  const filtered = status ? items.filter((item) => item.status === status) : items;
+  return filtered.map((item) => cloneContract(item));
+}
+
+export function getOrder(identifier: string): OrderContract | null {
+  const order = findOrder(identifier);
+  return order ? cloneContract(order) : null;
+}
+
+export function cancelOrder(identifier: string): OrderContract | null {
+  const order = findOrder(identifier);
+  if (!order) {
+    return null;
+  }
+  order.status = mapCancelTransition(order.status);
+  return cloneContract(order);
+}
+
+function mapCancelTransition(current: OrderStatus): OrderStatus {
+  if (current === 'filled') {
+    return 'filled';
+  }
+  if (current === 'cancelled') {
+    return 'cancelled';
+  }
+  return 'cancelled';
+}
+
+export function listPortfolios(): PortfolioContract[] {
+  return Array.from(portfolios.values()).map((item) => cloneContract(item));
+}
+
+export function getPortfolio(portfolioId: string): PortfolioContract | null {
+  const portfolio = portfolios.get(portfolioId);
+  return portfolio ? cloneContract(portfolio) : null;
+}
+
+export function resetExecutionStore(): void {
+  seedStore();
+}

--- a/src/lib/types/execution-contract.ts
+++ b/src/lib/types/execution-contract.ts
@@ -1,0 +1,51 @@
+export type DeploymentStatus =
+  | 'queued'
+  | 'running'
+  | 'paused'
+  | 'stopping'
+  | 'stopped'
+  | 'failed';
+
+export type OrderStatus = 'pending' | 'filled' | 'cancelled' | 'rejected' | 'failed';
+
+export interface DeploymentContract {
+  id: string;
+  strategyId: string;
+  mode: 'paper' | 'live';
+  status: DeploymentStatus;
+  capital: number;
+  providerRefId: string;
+  latestPnl: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OrderContract {
+  id: string;
+  providerOrderId: string;
+  symbol: string;
+  side: 'buy' | 'sell';
+  type: 'market' | 'limit';
+  quantity: number;
+  price: number | null;
+  status: OrderStatus;
+  deploymentId: string | null;
+  createdAt: string;
+}
+
+export interface PortfolioPositionContract {
+  symbol: string;
+  quantity: number;
+  avgPrice: number;
+  currentPrice: number;
+  unrealizedPnl: number;
+}
+
+export interface PortfolioContract {
+  id: string;
+  mode: 'paper' | 'live';
+  cash: number;
+  totalValue: number;
+  pnlTotal: number | null;
+  positions: PortfolioPositionContract[];
+}


### PR DESCRIPTION
## Summary
- introduce internal execution contract DTOs (`DeploymentContract`, `OrderContract`, `PortfolioContract`)
- add internal route surface under `/api/internal/*` for deployments/orders/portfolios
- align route payload semantics to Platform `LiveEngineExecutionAdapter` expectations
- add deterministic internal execution store tests and npm test script

## Testing
- `pnpm test`
- `pnpm typecheck`

Fixes iamtxena/trade-nexus#36
Refs iamtxena/trade-nexus#79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new server API routes that create/stop deployments and place/cancel orders; while currently backed by an in-memory store, the endpoints and validation semantics could affect downstream adapter integrations if incorrect.
> 
> **Overview**
> Adds a new authenticated internal execution API surface under `/api/internal/*` for deployments, orders, and portfolios, including lifecycle actions (`POST /deployments` + `POST /deployments/:id/stop`, `POST /orders` + `DELETE /orders/:id`) and list/get endpoints with consistent JSON payloads and error handling.
> 
> Introduces adapter-aligned DTO types (`DeploymentContract`, `OrderContract`, `PortfolioContract`) and a deterministic in-memory `execution-store` that supports lookup by either internal IDs or provider reference IDs and applies basic state transitions (stop/cancel). Adds Node test coverage for these transitions/lookup semantics and wires up `pnpm test` via a new `package.json` script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e078fee59ccef8d0b8c11ece04695743ec8eab2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Introduced a new internal execution API surface under `/api/internal/*` that aligns with the Platform `LiveEngineExecutionAdapter` contract expectations. The PR adds contract DTOs (`DeploymentContract`, `OrderContract`, `PortfolioContract`), a deterministic in-memory execution store with seed data, and REST endpoints for managing deployments, orders, and portfolios.

**Key changes:**
- Created execution contract types with proper status enums and field definitions
- Implemented in-memory store with provider-id lookup (supports both internal IDs like `dep-001` and provider ref IDs like `live-dep-001`)
- Added 8 new API routes under `/api/internal/*` with Clerk/service-key authentication via `getAuthUserId`
- Implemented lifecycle transitions: deployment stop operations (`queued`→`stopping`) and order cancellation (`pending`→`cancelled`)
- Added deterministic Node.js tests and `pnpm test` script

**Issues found:**
- Limit order validation doesn't properly handle explicit `price: null` in request body - will incorrectly accept invalid payloads
- Minor code style: redundant condition in `mapCancelTransition` function

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logic fix needed for limit order validation
- The implementation is well-structured with proper auth, consistent error handling, and good test coverage. One logic bug in limit order validation could allow invalid requests to pass through (when `price: null` is explicitly sent). The in-memory store design is appropriate for the adapter contract and includes proper defensive cloning. Minor style issue is non-blocking.
- `src/app/api/internal/orders/route.ts` needs the limit order validation fix before merge

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/types/execution-contract.ts | added execution contract type definitions for deployments, orders, and portfolios - all types are well-structured |
| src/lib/internal/execution-store.ts | implemented in-memory execution store with seed data and provider-id lookup - minor redundant logic in `mapCancelTransition` |
| src/app/api/internal/deployments/route.ts | implemented POST/GET endpoints for deployments with proper auth and validation |
| src/app/api/internal/orders/route.ts | implemented POST/GET endpoints for orders with validation - `price: null` validation for limit orders has a logic issue |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Platform as Platform/Adapter
    participant Auth as getAuthUserId
    participant API as Internal API Routes
    participant Store as ExecutionStore
    
    Platform->>API: POST /api/internal/deployments
    API->>Auth: verify auth (Clerk or SERVICE_API_KEY)
    Auth-->>API: userId or service-account
    API->>Store: createDeployment(strategyId, mode, capital)
    Store->>Store: generate dep-XXX id + live-dep-XXX providerRefId
    Store-->>API: DeploymentContract (status: queued)
    API-->>Platform: 201 {deployment}
    
    Platform->>API: POST /api/internal/orders
    API->>Auth: verify auth
    Auth-->>API: userId
    API->>Store: placeOrder(symbol, side, type, quantity, price)
    Store->>Store: generate ord-XXX id + live-order-XXX providerOrderId
    Store-->>API: OrderContract (status: pending)
    API-->>Platform: 201 {order}
    
    Platform->>API: GET /api/internal/deployments/{providerRefId}
    API->>Auth: verify auth
    Auth-->>API: userId
    API->>Store: getDeployment(providerRefId)
    Store->>Store: lookup by id OR providerRefId
    Store-->>API: DeploymentContract
    API-->>Platform: 200 {deployment}
    
    Platform->>API: POST /api/internal/deployments/{id}/stop
    API->>Auth: verify auth
    Auth-->>API: userId
    API->>Store: stopDeployment(id)
    Store->>Store: transition status to 'stopping'
    Store-->>API: DeploymentContract (status: stopping)
    API-->>Platform: 200 {deployment}
    
    Platform->>API: DELETE /api/internal/orders/{providerOrderId}
    API->>Auth: verify auth
    Auth-->>API: userId
    API->>Store: cancelOrder(providerOrderId)
    Store->>Store: transition status to 'cancelled'
    Store-->>API: OrderContract (status: cancelled)
    API-->>Platform: 200 {order}
```

<sub>Last reviewed commit: 5ffccc1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->